### PR TITLE
feat(core): register virtrtlab bus type and sysfs kobject tree

### DIFF
--- a/kernel/virtrtlab_core.c
+++ b/kernel/virtrtlab_core.c
@@ -20,7 +20,7 @@
  * Bus type — visible in /sys/bus/virtrtlab/
  */
 
-static const struct bus_type virtrtlab_bus_type = {
+static struct bus_type virtrtlab_bus_type = {
 	.name = "virtrtlab",
 };
 


### PR DESCRIPTION
## Contexte
Closes #1

Implémentation du bus virtuel `virtrtlab` et de l'arbre kobject sysfs, première brique du MVP v0.1.0.

## Changements

- Enregistrement de `const struct bus_type virtrtlab_bus_type` via `bus_register()` → visible dans `/sys/bus/virtrtlab/`
- Arbre kobject ancré sur `kernel_kobj` :
  - `/sys/kernel/virtrtlab/`
  - `/sys/kernel/virtrtlab/version` (ro, retourne `0.1.0`)
  - `/sys/kernel/virtrtlab/buses/`
  - `/sys/kernel/virtrtlab/devices/`
- Pattern `goto err_*` complet sur tous les chemins d'erreur (ordre inverse)
- Déchargement propre : `kobject_put` + `sysfs_remove_group` + `bus_unregister`

## Tests effectués

- [x] `make KDIR=~/projects/WSL2-Linux-Kernel` passe sans erreur ni warning
- [x] Module charge/décharge sans oops (`dmesg` : `loaded (v0.1.0)` / `unloaded`)
- [x] `/sys/kernel/virtrtlab/version` retourne `0.1.0`
- [x] `/sys/bus/virtrtlab/` existe après `insmod`
- [x] `checkpatch.pl --strict` : 0 errors, 0 warnings

## Notes pour le reviewer

- Le BTF mismatch dans `dmesg` est un artefact WSL2 (kernel Microsoft vs sources compilées), sans impact fonctionnel.
- Transport netlink/misc device hors scope (issue #5).
- Les modules périphériques (`virtrtlab_uart`, etc.) s'enregistreront sur ce bus dans les issues suivantes.