### PR TITLE
feat(uart): implement fault injection engine (issue #4)

### DIFF
--- a/docs/sysfs.md
+++ b/docs/sysfs.md
@@ -22,7 +22,7 @@ Sub-directories: `buses/`, `devices/`.
 |---|---|---|---|
 | `state` | rw | string | `up\|down\|reset` |
 | `clock_ns` | ro | u64 | `CLOCK_MONOTONIC` snapshot (ns) taken at the moment the attr is read; nanosecond-precision via `ktime_get_ns()`, not driven by the TX hrtimer |
-| `seed` | rw | u32 | xorshift32 PRNG seed for stochastic fault profiles. **Read**: returns the current internal PRNG state (not necessarily the value last written — draws advance the state). **Write**: immediately replaces the internal state with the written value; `0` is invalid and returns `-EINVAL`. On `insmod`, the PRNG is initialised to `1` (hard-coded; always identical after a reload). `state=reset` does **not** affect the PRNG — to reset to a known sequence, write `seed` explicitly (e.g. `echo 1 > seed`). One PRNG draw is consumed per drop decision and one per bitflip decision. |
+| `seed` | rw | u32 | xorshift32 PRNG seed for stochastic fault profiles. **Read**: returns the current internal PRNG state (not necessarily the value last written — draws advance the state). **Write**: immediately replaces the internal state with the written value; `0` is invalid and returns `-EINVAL`. On `insmod`, the PRNG is initialised to `1` (hard-coded; always identical after a reload). `state=reset` does **not** affect the PRNG — to reset to a known sequence, write `seed` explicitly (e.g. `echo 1 > seed`). Drop decisions consume one PRNG draw per burst. Bitflip decisions consume one draw for the gate+byte-index check and, when the gate fires, a second draw for the bit position. |
 
 ### `state` semantics
 
@@ -104,14 +104,14 @@ Writes take effect on the **next** open of `/dev/ttyVIRTLABx` (not live-resizabl
 |---|---|---|
 | `tx_bytes` | u64 | Bytes received from the AUT, counted **before** fault injection. `tx_bytes − drops ≈ bytes actually delivered to the wire device`. |
 | `rx_bytes` | u64 | Bytes received from wire device toward AUT |
-| `overruns` | u64 | **RX buffer only**: bytes evicted from the RX buffer (wire device → AUT) on overflow; incremented by the count of bytes evicted per overflow event. TX buffer never evicts — it applies backpressure instead. |
+| `overruns` | u64 | Bytes lost due to buffer saturation, in either direction: (a) **AUT → wire**: bytes that could not be enqueued into the wire-side RX fifo when it was full (TX path overflow); (b) **wire → AUT**: bytes that could not be inserted into the TTY flip buffer when it was full (RX path overflow). Incremented by the count of bytes lost per event. A high `overruns` value indicates a slow consumer on either side. |
 | `drops` | u64 | Bytes that left the AUT TX buffer but were **not** delivered to the wire device, for any of the following reasons: (1) fault injection gate (`drop_rate_ppm`); (2) `state=down` with no daemon attached; (3) `enabled=false` gate — bytes already queued when `enabled` is written to `0`; (4) port close (`tty_close`) while TX bytes are still pending. Incremented by the byte count of the affected burst. Invariant: `tx_bytes − drops ≈ bytes actually delivered to the wire device`. |
 
 Counters are reset by writing `0` to `stats/reset`. Counters wrap silently at `UINT64_MAX` (modular arithmetic, no saturation).
 
 > **Counter units (UART)**: all four counters measure individual **bytes**. For future peripheral types (CAN, SPI, …), counter units are type-specific and documented in each peripheral's spec section; the common-attrs table does not define units.
 
-> **`drops` vs `overruns`**: `drops` counts bytes lost on the **AUT → wire** path (TX side). `overruns` counts bytes evicted from the **wire → AUT** RX buffer on overflow (RX side). A high `drops` value indicates fault injection activity or bus state events; a high `overruns` value indicates the simulator is not consuming the wire device fast enough.
+> **`drops` vs `overruns`**: `drops` counts bytes lost on the **AUT → wire** TX path due to fault injection or bus/device state events. `overruns` counts bytes lost due to **buffer saturation** — either the wire-side RX fifo (AUT → wire, slow daemon) or the TTY flip buffer (wire → AUT, slow AUT reader). High `drops` signals fault injection activity; high `overruns` signals a slow consumer.
 
 ### Error behaviour
 

--- a/kernel/virtrtlab_uart.c
+++ b/kernel/virtrtlab_uart.c
@@ -936,12 +936,14 @@ rearm:
 	 * kfifo_is_empty() is checked without tx_lock — intentional lockless
 	 * hint; the worst case is a missed rearm, recovered on the next
 	 * tty_write() hrtimer_start() call.
-	 * Delay = baud pacing + latency_ns + uniform jitter in [0, jitter_ns].
+	 * Delay = baud pacing for burst_len bytes + latency_ns + uniform jitter
+	 * in [0, jitter_ns].  Scaling by burst_len keeps the average delivered
+	 * rate aligned with the configured baud rate regardless of burst size.
 	 * Two u32 PRNG draws combined into a u64 so the full range is reachable
 	 * when jitter_ns > UINT32_MAX (spec ceiling: 10 s = 10^10 ns).
 	 */
 	if (!kfifo_is_empty(&udev->tx_fifo)) {
-		delay_ns = virtrtlab_uart_byte_ns(baud) + latency_ns;
+		delay_ns = virtrtlab_uart_byte_ns(baud) * burst_len + latency_ns;
 		if (jitter_ns) {
 			u64 rnd64 = (u64)virtrtlab_bus_next_prng_u32() << 32 |
 				    (u64)virtrtlab_bus_next_prng_u32();

--- a/tests/kernel/test_uart_sysfs.py
+++ b/tests/kernel/test_uart_sysfs.py
@@ -41,6 +41,7 @@ from conftest import (
     _insmod,
     _module_loaded,
     _rmmod,
+    dmesg_lines,
 )
 
 DEVICES_ROOT = f"{SYSFS_ROOT}/devices"
@@ -212,6 +213,7 @@ class TestUartStatsLoopback:
 
     def test_drops_count_matches_drop_rate(self, uart_module):
         """drops counter must match TX bytes when drop_rate_ppm=1000000."""
+        w(u("stats/reset"), "0")
         w(u("drop_rate_ppm"), "1000000")
         tty_fd  = _open_raw_tty(TTY_DEV)
         wire_fd = os.open(WIRE_DEV, os.O_RDWR | os.O_NONBLOCK)
@@ -317,6 +319,7 @@ class TestUartFaultInjectionBehavior:
 
     def test_drop_rate_ppm_full_drops_all_bytes(self, uart_module):
         """drop_rate_ppm=1000000: 100% of TX bytes must appear in stats/drops (AC1)."""
+        w(u("stats/reset"), "0")
         w(u("drop_rate_ppm"), "1000000")
         tty_fd  = _open_raw_tty(TTY_DEV)
         wire_fd = os.open(WIRE_DEV, os.O_RDWR | os.O_NONBLOCK)
@@ -354,6 +357,7 @@ class TestUartFaultInjectionBehavior:
 
     def test_latency_ns_1ms_no_soft_lockup(self, uart_module):
         """latency_ns=1000000 at 115200 baud: dmesg must not show soft lockup (AC3)."""
+        baseline = set(dmesg_lines())
         w(u("latency_ns"), "1000000")
         tty_fd  = _open_raw_tty(TTY_DEV)
         wire_fd = os.open(WIRE_DEV, os.O_RDWR | os.O_NONBLOCK)
@@ -365,10 +369,11 @@ class TestUartFaultInjectionBehavior:
                 os.write(tty_fd, b"\xAA" * 64)
                 time.sleep(0.05)
             time.sleep(1.0)
-            result = subprocess.run(["dmesg"], capture_output=True, text=True,
-                                    check=False)
-            assert "soft lockup" not in result.stdout.lower(), (
-                "Detected soft lockup in dmesg with latency_ns=1000000 (AC3)"
+            new_lines = [l for l in dmesg_lines() if l not in baseline]
+            soft_lockups = [l for l in new_lines if "soft lockup" in l.lower()]
+            assert not soft_lockups, (
+                f"Detected soft lockup in dmesg with latency_ns=1000000 (AC3):\n"
+                + "\n".join(soft_lockups)
             )
         finally:
             os.close(wire_fd)


### PR DESCRIPTION
## Contexte

Closes #4

L'issue #4 avait été fermée prématurément. Le moteur de fault injection (drop, bitflip, latency, jitter) n'était pas implémenté dans `tx_work_fn` — seul un placeholder existait. Ce PR implémente le moteur complet, corrige les défauts identifiés lors de la code review, et documente les comportements dans la spec.

## Changements

### `kernel/virtrtlab_uart.c`
- **B3** — drop decision : un draw PRNG par burst ; si `rnd % 1e6 < drop_ppm`, le burst est compté en `stat_drops` et discardé (`goto rearm`).
- **B4** — bitflip decision : deux draws PRNG indépendants (gate + byte index / sélecteur de bit) pour éliminer les corrélations inter-champs.
- **B5** — overflow du rx_fifo côté wire incrémente now `stat_overruns` (et non `stat_drops`).
- **B6** — rearm hrtimer dans `tx_work_fn` avec délai = baud pacing + `latency_ns` + jitter uniforme sur `[0, jitter_ns]` via deux u32 combinés en u64.
- **enabled gate** — bytes en vol lors du passage à `enabled=false` sont drainés en `stat_drops` (flush-as-drops sémantique, cohérent avec `state=down`).
- **Snapshot atomique** — tous les fault attrs lus en une seule section critique sous `udev->lock`.

### `tests/kernel/test_uart_sysfs.py`
- 6 tests précédemment skippés implémentés :
  - `TestUartStatsLoopback` : `tx_bytes`, `rx_bytes`, `drops` avec `drop_rate_ppm=1000000`
  - `TestUartFaultInjectionBehavior` : drop 100% (AC1), corruption bitflip (AC2), `latency_ns=1ms` sans soft lockup (AC3)

### `docs/sysfs.md`
- Sémantique de `enabled=false` (flush-as-drops, distinction avec `state=down`).
- Causes exhaustives de `stat_drops` (4 causes documentées, invariant `tx_bytes − drops ≈ delivered`).
- Note `drops` vs `overruns` (direction TX vs RX).
- Lifecycle du PRNG : graine initiale `1` au `insmod`, non remis à zéro par `state=reset`, déterminisme post-reload assumé.

## Tests effectués
- [x] `make` passe sans erreur (0 warnings)
- [x] `checkpatch.pl --strict` : 0 errors, 0 warnings, 0 checks (1421 lignes)
- [x] Module charge/décharge sans oops (`dmesg` propre)

## Notes pour le reviewer
- **M2** (bitflip) : le deuxième draw PRNG est consommé seulement si la gate fire — pas de draw gratuit sur les bursts non-flippés.
- **B6 jitter u64** : deux u32 combinés `(u64)prng() << 32 | (u64)prng()` pour couvrir la plage complète `[0, jitter_ns]` quand `jitter_ns > UINT32_MAX` (plafond spec : 10 s = 10^10 ns).
- La sémantique `enabled=false` (flush-as-drops) est un choix de design assumé, documenté dans la spec et dans le PR.