### PR TITLE
docs: add license files and SPDX headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,280 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it. By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users. This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it. (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.) You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price. Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have. You must make sure that they, too, receive or can get the
+source code. And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software. If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents. We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary. To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License. The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language. (Hereinafter, translation is included without limitation in
+the term "modification".) Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope. The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License. (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole. If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works. But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code. (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it. For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable. However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License. Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it. However, nothing else grants you permission to modify or
+distribute the Program or its derivative works. These actions are
+prohibited by law if you do not accept this License. Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions. You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License. If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all. For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices. Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded. In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time. Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation. If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission. For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this. Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS

--- a/LICENSE.CC-BY-4.0
+++ b/LICENSE.CC-BY-4.0
@@ -1,0 +1,22 @@
+Creative Commons Attribution 4.0 International
+
+This repository documents its prose specifications under CC BY 4.0.
+
+License deed: https://creativecommons.org/licenses/by/4.0/
+Legal code: https://creativecommons.org/licenses/by/4.0/legalcode
+
+You are free to:
+
+- Share — copy and redistribute the material in any medium or format
+- Adapt — remix, transform, and build upon the material for any purpose,
+  even commercially
+
+Under the following terms:
+
+- Attribution — You must give appropriate credit, provide a link to the
+  license, and indicate if changes were made. You may do so in any reasonable
+  manner, but not in any way that suggests the licensor endorses you or your
+  use.
+
+No additional restrictions — You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.

--- a/LICENSE.MIT
+++ b/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 VirtRTLab contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # VirtRTLab
 
 VirtRTLab is a Linux/POSIX real-time testing framework based on **kernel modules** that simulate common peripherals on a **virtual bus**.
@@ -391,4 +393,8 @@ See `tests/README.md` for the repository-level test layout.
 
 ## License
 
-TBD
+Kernel modules in `kernel/` are licensed under [GPL-2.0-only](LICENSE).
+
+Userspace tools in `cli/`, `daemon/`, and Python tests in `tests/` are licensed under [MIT](LICENSE.MIT).
+
+Documentation in `README.md`, `docs/`, `cli/README.md`, `kernel/README.md`, and `tests/README.md` is licensed under [CC BY 4.0](LICENSE.CC-BY-4.0).

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # CLI tooling
 
 The `v0.1.0` CLI target is split into two roles:

--- a/cli/virtrtlabctl.py
+++ b/cli/virtrtlabctl.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+
 """virtrtlabctl — VirtRTLab control CLI."""
 
 import argparse

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 CC      = gcc
 CFLAGS  = -Wall -Wextra -O2 -std=gnu11
 

--- a/daemon/epoll_loop.c
+++ b/daemon/epoll_loop.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: MIT */
 /*
  * epoll_loop.c — shared epoll event loop for virtrtlabd
  *

--- a/daemon/epoll_loop.h
+++ b/daemon/epoll_loop.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: MIT */
 /*
  * epoll_loop.h — shared epoll instance for virtrtlabd
  *

--- a/daemon/instance.c
+++ b/daemon/instance.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: MIT */
 /*
  * instance.c — per-UART relay state machine for virtrtlabd
  *

--- a/daemon/instance.h
+++ b/daemon/instance.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: MIT */
 /*
  * instance.h — per-UART instance state for virtrtlabd
  *

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0 */
+/* SPDX-License-Identifier: MIT */
 /*
  * main.c — virtrtlabd startup, argument parsing, and lifecycle
  *

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # Docs
 
 - Sysfs: [sysfs.md](sysfs.md)

--- a/docs/socket-api.md
+++ b/docs/socket-api.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # VirtRTLab — Wire device and daemon socket (v1)
 
 Source of truth is the root [README.md](../README.md). This file keeps transport details focused.

--- a/docs/sysfs.md
+++ b/docs/sysfs.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # VirtRTLab sysfs (v1)
 
 Source of truth is the root [README.md](../README.md). This file keeps sysfs-specific details focused.

--- a/docs/virtrtlabctl.md
+++ b/docs/virtrtlabctl.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # VirtRTLab — `virtrtlabctl` CLI (v1)
 
 Source of truth is the root [README.md](../README.md). This file keeps CLI-specific

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # Kernel modules (stubs)
 
 This folder contains initial **out-of-tree** kernel module stubs for VirtRTLab.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
 # Test strategy
 
 All automated validation lives under `tests/` so local runs and GitHub Actions use the same layout, fixtures, and reporting.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 conftest.py — shared fixtures for virtrtlabctl CLI tests.
 

--- a/tests/cli/test_daemon.py
+++ b/tests/cli/test_daemon.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_daemon.py — integration tests for cmd_daemon.
 

--- a/tests/cli/test_profile.py
+++ b/tests/cli/test_profile.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_profile.py — unit tests for lab profile resolution.
 

--- a/tests/cli/test_sysfs.py
+++ b/tests/cli/test_sysfs.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_sysfs.py — unit tests for sysfs CRUD commands.
 

--- a/tests/cli/test_up_down.py
+++ b/tests/cli/test_up_down.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_up_down.py — integration tests for cmd_up and cmd_down.
 

--- a/tests/daemon/conftest.py
+++ b/tests/daemon/conftest.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 conftest.py — shared fixtures for VirtRTLab daemon integration tests.
 

--- a/tests/daemon/test_daemon_reconnect.py
+++ b/tests/daemon/test_daemon_reconnect.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_daemon_reconnect.py — reconnect test for virtrtlabd (issue #10).
 

--- a/tests/daemon/test_daemon_relay.py
+++ b/tests/daemon/test_daemon_relay.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_daemon_relay.py — byte relay tests for virtrtlabd (issue #10).
 

--- a/tests/daemon/test_daemon_shutdown.py
+++ b/tests/daemon/test_daemon_shutdown.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_daemon_shutdown.py — shutdown tests for virtrtlabd (issue #10).
 

--- a/tests/daemon/test_daemon_startup.py
+++ b/tests/daemon/test_daemon_startup.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_daemon_startup.py — daemon startup tests for virtrtlabd (issue #10).
 

--- a/tests/kernel/conftest.py
+++ b/tests/kernel/conftest.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 conftest.py — shared pytest fixtures for VirtRTLab kernel integration tests.
 

--- a/tests/kernel/test_core_load.py
+++ b/tests/kernel/test_core_load.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_core_load.py — load/unload tests for virtrtlab_core.
 

--- a/tests/kernel/test_core_sysfs.py
+++ b/tests/kernel/test_core_sysfs.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_core_sysfs.py — sysfs contract tests for virtrtlab_core (issue #13).
 

--- a/tests/kernel/test_gpio_inject.py
+++ b/tests/kernel/test_gpio_inject.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_gpio_inject.py — dedicated inject mechanism tests for virtrtlab_gpio v0.2.0.
 

--- a/tests/kernel/test_gpio_load.py
+++ b/tests/kernel/test_gpio_load.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_gpio_load.py — load/unload tests for virtrtlab_gpio.
 

--- a/tests/kernel/test_gpio_sysfs.py
+++ b/tests/kernel/test_gpio_sysfs.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_gpio_sysfs.py — sysfs contract tests for virtrtlab_gpio v0.2.0.
 

--- a/tests/kernel/test_uart_load.py
+++ b/tests/kernel/test_uart_load.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_uart_load.py — load/unload tests for virtrtlab_uart.
 

--- a/tests/kernel/test_uart_sysfs.py
+++ b/tests/kernel/test_uart_sysfs.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_uart_sysfs.py — sysfs contract tests for virtrtlab_uart.
 

--- a/tests/kernel/test_uart_wire.py
+++ b/tests/kernel/test_uart_wire.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 test_uart_wire.py — data-plane integration tests for virtrtlab_uart wire device.
 


### PR DESCRIPTION
## Contexte
Closes #37

The repository had no root license file and several userspace, daemon, test, and documentation files were missing SPDX headers. This made the licensing status unclear for contributors and adopters.

## Changements
- add root license files for GPL-2.0-only, MIT, and CC BY 4.0
- add SPDX headers to userspace, daemon, tests, and documentation files
- document the repository license split in README

## Tests effectués
- [x] `make -C daemon clean && make -C daemon`
- [x] Python source parsing validated for `cli/` and `tests/`
- [ ] `make` passes in `kernel/`
- [ ] `checkpatch.pl --strict` passes

## Notes pour le reviewer
- License split applied:
  - `kernel/` -> GPL-2.0-only
  - `cli/`, `daemon/`, `tests/` -> MIT
  - docs -> CC BY 4.0
- `LICENSE.CC-BY-4.0` currently points to the legal code and deed rather than embedding the full legal text.