### PR TITLE
docs: tighten v0.2.0 specification contracts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,10 +5,19 @@
 | Document | Audience | Contents |
 |---|---|---|
 | [../README.md](../README.md) | All users | Project overview, installation, getting started, examples |
+| Current docs without `-v0.2.0` suffix | Users / operators | Stable contract for the current implementation (`v0.1.x` world) |
+| Draft docs with `-v0.2.0` suffix | Contributors / reviewers | Forward-looking contract for the planned hotplug-capable `v0.2.0` architecture |
 | [virtrtlabctl.md](virtrtlabctl.md) | Users | Complete CLI reference — all commands, options, output formats, exit codes |
-| [virtrtlabctl-v0.2.0.md](virtrtlabctl-v0.2.0.md) | Contributors | Draft CLI additions for `v0.2.0` — simulator catalog, attachments, lifecycle commands |
+| [v0.2.0/virtrtlabctl-v0.2.0.md](v0.2.0/virtrtlabctl-v0.2.0.md) | Contributors | Draft CLI additions for `v0.2.0` — simulator catalog, attachments, lifecycle commands |
 | [daemon.md](daemon.md) | Users | `virtrtlabd` user guide — startup, signals, reconnect, logging, systemd |
+| [v0.2.0/daemon-v0.2.0.md](v0.2.0/daemon-v0.2.0.md) | Contributors | Draft daemon contract for `v0.2.0` — authoritative control plane, dynamic topology, simulator supervision |
+| [v0.2.0/daemon-config-v0.2.0.md](v0.2.0/daemon-config-v0.2.0.md) | Contributors | Draft daemon configuration contract for `v0.2.0` — runtime paths, socket layout, logging |
 | [sysfs.md](sysfs.md) | Users / integrators | sysfs attribute reference — buses, devices, fault attrs, stats, error conditions |
 | [socket-api.md](socket-api.md) | Integrators / contributors | Wire device and daemon socket transport specification, epoll loop, relay state machine |
-| [simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md) | Integrators / contributors | Draft simulator contract for `v0.2.0` — catalog format, attachment model, runtime environment |
+| [v0.2.0/socket-api-v0.2.0.md](v0.2.0/socket-api-v0.2.0.md) | Integrators / contributors | Draft `v0.2.0` device dataplane socket specification — per-device sockets separate from control |
+| [v0.2.0/control-socket-v0.2.0.md](v0.2.0/control-socket-v0.2.0.md) | Integrators / contributors | Draft `v0.2.0` control-plane protocol — JSONL request/response API over `/run/virtrtlab/control.sock` |
+| [v0.2.0/simulator-contract-v0.2.0.md](v0.2.0/simulator-contract-v0.2.0.md) | Integrators / contributors | Draft simulator contract for `v0.2.0` — catalog format, attachment model, runtime environment |
+| [v0.2.0/driver-contract-v0.2.0.md](v0.2.0/driver-contract-v0.2.0.md) | Integrators / contributors | Draft `v0.2.0` driver contract — hotplug, discovery, observability, and control obligations |
 | [spec.md](spec.md) | Contributors | Architecture and interface specification — naming conventions, data paths, design decisions, milestones |
+| [v0.2.0/spec-v0.2.0.md](v0.2.0/spec-v0.2.0.md) | Contributors | Draft `v0.2.0` architecture — dynamic topology, daemonized control plane, driver integration |
+| [v0.2.0/privilege-model-v0.2.0.md](v0.2.0/privilege-model-v0.2.0.md) | Contributors | Draft `v0.2.0` privilege model — non-root daemon-mediated control, socket permissions, service role |

--- a/docs/v0.2.0/control-socket-v0.2.0.md
+++ b/docs/v0.2.0/control-socket-v0.2.0.md
@@ -579,6 +579,25 @@ Rules:
 - returns the post-reset `stats` object
 - does not modify non-stat attributes
 
+### Action naming rule
+
+All action names follow the scheme `<namespace>.<verb>` where `<verb>` MAY
+include one underscore-delimited qualifier to distinguish related operations
+within the same namespace (for example `stats_reset` vs `stats`, or
+`profile_apply` vs `profile_clear`). Namespaces and verbs are lowercase ASCII
+with no hyphens.
+
+| Namespace | Domain |
+|---|---|
+| `lab` | lab-level lifecycle and topology |
+| `device` | individual device operations |
+| `fault` | fault injection and profile management |
+| `sim` | simulator lifecycle and attachment |
+| `events` | event stream subscription |
+
+Clients MUST treat unrecognised action names as unsupported and MUST NOT infer
+semantics from partial name matching.
+
 ### 5.3 `fault.*`
 
 | Action | Purpose |

--- a/docs/v0.2.0/control-socket-v0.2.0.md
+++ b/docs/v0.2.0/control-socket-v0.2.0.md
@@ -301,9 +301,31 @@ Success result fields:
 | `daemon.control_api_framing` | string | control API framing identifier, initial value `jsonl` |
 | `devices` | array | current device summaries |
 | `simulators` | array | current simulator attachment summaries |
-| `capabilities` | array | driver capability summaries known to the daemon |
+| `capabilities` | array | driver capability summaries known to the daemon, including discoverable attr maxima when the driver advertises them |
 
 `lab.status` is read-only and must not mutate topology or simulator state.
+
+Illustrative capability summary:
+
+```json
+{
+  "type": "uart",
+  "hotplug": true,
+  "max_devices": 8,
+  "line_count": null,
+  "latency_ns_max": 1000000000,
+  "jitter_ns_max": 1000000000,
+  "persistent_attrs": [
+    "enabled",
+    "latency_ns",
+    "jitter_ns",
+    "drop_rate_ppm",
+    "bitflip_rate_ppm"
+  ],
+  "injection_kinds": ["rx-bytes"],
+  "path_keys": ["aut_path", "data_path", "sysfs_path"]
+}
+```
 
 #### `lab.apply_profile`
 
@@ -492,6 +514,7 @@ Rules:
 - unknown writable keys return `unknown-attribute`
 - read-only keys return `read-only-attribute`
 - common persistent-attribute validation follows the driver-contract ranges: `enabled` is boolean, `latency_ns` and `jitter_ns` are non-negative nanosecond integers subject to implementation maxima, and `drop_rate_ppm` plus `bitflip_rate_ppm` are integers in the inclusive range `0..1000000`
+- when the target driver advertises `latency_ns_max` or `jitter_ns_max` in its capability object, values above those maxima return `invalid-value`
 
 Success result:
 
@@ -1035,6 +1058,25 @@ Recommended action-specific error mapping:
 | `sim.stop` | attachment absent | `not-attached` |
 | `sim.stop` | attachment exists but is not live and not `stopped` | `state-conflict` |
 | `sim.status` with `device` | device exists but attachment absent | `not-attached` |
+
+Illustrative incompatible-target error:
+
+```json
+{
+  "id": "req-attach-2",
+  "ok": false,
+  "error": {
+    "code": "incompatible-target",
+    "message": "simulator loopback does not support device type gpio",
+    "retryable": false,
+    "details": {
+      "device": "gpio0",
+      "device_type": "gpio",
+      "simulator": "loopback"
+    }
+  }
+}
+```
 
 ## 7. Versioning
 

--- a/docs/v0.2.0/control-socket-v0.2.0.md
+++ b/docs/v0.2.0/control-socket-v0.2.0.md
@@ -34,7 +34,7 @@ In `v0.2.0`, VirtRTLab exposes one canonical control endpoint:
 
 | Property | Value |
 |---|---|
-| Path | `/run/virtrtlab/control.sock` |
+| Path | resolved daemon control-socket path; default installed path `/run/virtrtlab/control.sock` |
 | Address family | `AF_UNIX` |
 | Socket type | `SOCK_STREAM` |
 | Framing | UTF-8 JSON Lines (`\n`-terminated objects) |
@@ -44,6 +44,10 @@ Each request is one JSON object on one line. Each response is one JSON object on
 one line.
 
 Requests and responses are correlated by a client-supplied `id` field.
+
+Unless a surrounding rule says otherwise, JSON objects shown in this document
+are illustrative examples. Field presence, requiredness, and error behavior are
+defined by the accompanying tables and rules.
 
 ## 3. Connection model
 
@@ -185,20 +189,29 @@ Success result:
       {
         "name": "uart0",
         "type": "uart",
-        "aut_path": "/dev/ttyVIRTLAB0",
-        "data_path": "/run/virtrtlab/devices/uart0.sock"
+        "paths": {
+          "aut_path": "/dev/ttyVIRTLAB0",
+          "data_path": "/run/virtrtlab/devices/uart0.sock",
+          "sysfs_path": "/sys/kernel/virtrtlab/devices/uart0"
+        }
       },
       {
         "name": "uart1",
         "type": "uart",
-        "aut_path": "/dev/ttyVIRTLAB1",
-        "data_path": "/run/virtrtlab/devices/uart1.sock"
+        "paths": {
+          "aut_path": "/dev/ttyVIRTLAB1",
+          "data_path": "/run/virtrtlab/devices/uart1.sock",
+          "sysfs_path": "/sys/kernel/virtrtlab/devices/uart1"
+        }
       },
       {
         "name": "gpio0",
         "type": "gpio",
-        "chip_path": "/dev/gpiochip4",
-        "data_path": "/run/virtrtlab/devices/gpio0.sock"
+        "paths": {
+          "chip_path": "/dev/gpiochip4",
+          "data_path": "/run/virtrtlab/devices/gpio0.sock",
+          "sysfs_path": "/sys/kernel/virtrtlab/devices/gpio0"
+        }
       }
     ],
     "attachments": [
@@ -215,9 +228,18 @@ Success result:
 Behavior:
 
 - validates the full requested topology before partial creation
+- reconciles the active lab toward the requested set from any stable lab state
 - creates and destroys devices to match the requested set
 - applies declared attachments after the requested topology exists
 - starts only attachments whose effective `auto_start` is `true`
+
+Mutation phases:
+
+| Phase | Atomicity rule |
+|---|---|
+| topology and attachment-definition validation | all-or-nothing; any validation error prevents mutation |
+| device inventory and attachment-definition reconciliation | all-or-nothing; if this phase fails, the previously stable topology and attachment definitions remain visible |
+| simulator auto-start for attachments whose effective `auto_start` is `true` | not rolled back automatically; a failure returns structured partial-state details |
 
 Validation rules:
 
@@ -225,6 +247,12 @@ Validation rules:
 - duplicate `type` entries in one request are invalid
 - `count` must be a positive integer and must not exceed the advertised driver capability limit
 - attachment validation is atomic with topology validation; an invalid attachment prevents any topology mutation
+
+Failure rules:
+
+- if device create, device destroy, or attachment-definition materialization fails after successful validation, `lab.up` returns failure and the previously stable topology remains visible
+- if simulator auto-start is only partially successful after successful reconciliation, `lab.up` returns failure with partial state details; the reconciled topology and attachment definitions remain in effect
+- clients must treat `lab.up` as a target-state reconcile operation, not as an `empty -> up` bootstrap only
 
 #### `lab.down` result
 
@@ -309,6 +337,7 @@ Rules:
 - `lab.apply_profile` replaces the active lab topology with the resolved target profile
 - profile validation is atomic
 - if simulator auto-start is only partially successful after validation, the command returns failure with partial state details, matching the CLI contract
+- topology and attachment-definition reconciliation follow the same all-or-nothing rules as `lab.up`
 
 ### 5.2 `device.*`
 
@@ -435,7 +464,7 @@ Success result fields:
 |---|---|---|
 | `name` | string | device name |
 | `type` | string | device type |
-| `state` | string | current lifecycle state |
+| `state` | string | current device lifecycle state; one of `creating`, `up`, `resetting`, `destroying`, or `error` |
 | `paths` | object | resolved AUT, dataplane, and sysfs paths |
 | `attrs` | object | current control-plane-visible attributes |
 | `stats` | object | current per-device stats counters |
@@ -462,6 +491,7 @@ Rules:
 - all field validation is atomic per request: if one value is invalid, none are applied
 - unknown writable keys return `unknown-attribute`
 - read-only keys return `read-only-attribute`
+- common persistent-attribute validation follows the driver-contract ranges: `enabled` is boolean, `latency_ns` and `jitter_ns` are non-negative nanosecond integers subject to implementation maxima, and `drop_rate_ppm` plus `bitflip_rate_ppm` are integers in the inclusive range `0..1000000`
 
 Success result:
 
@@ -978,6 +1008,7 @@ The following `error.code` values are stable in `v0.2.0`:
 | `read-only-attribute` | write attempted on a read-only key |
 | `invalid-value` | attribute value failed range or type validation |
 | `invalid-payload` | injection or structured request payload failed validation |
+| `incompatible-target` | referenced objects exist but cannot be combined for the requested operation |
 | `kernel-failure` | daemon could not complete the requested kernel-side operation |
 | `simulator-failure` | simulator process launch or stop failed |
 | `not-attached` | simulator lifecycle action referenced an existing device without an attachment |
@@ -997,7 +1028,7 @@ Recommended action-specific error mapping:
 | `fault.inject` | unknown injection kind for device type | `invalid-payload` |
 | `sim.inspect` | ambiguous simulator version | `ambiguous-simulator-version` |
 | `sim.attach` | ambiguous simulator version | `ambiguous-simulator-version` |
-| `sim.attach` | simulator unsupported for device type | `invalid-request` |
+| `sim.attach` | simulator unsupported for device type | `incompatible-target` |
 | `sim.detach` | device has no attachment | `not-attached` |
 | `sim.start` | device has no attachment | `not-attached` |
 | `sim.start` | attachment already `running` or `starting` | `state-conflict` |

--- a/docs/v0.2.0/control-socket-v0.2.0.md
+++ b/docs/v0.2.0/control-socket-v0.2.0.md
@@ -1,0 +1,1050 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# VirtRTLab Control Socket (v0.2.0 Draft)
+
+This document is the source of truth for the `v0.2.0` control plane.
+
+It defines the daemon-mediated interface used by `virtrtlabctl` and other
+authorized clients to manage lab topology, device configuration, fault
+injection, and simulator lifecycle without requiring full root access for
+routine operations.
+
+The UART byte-stream transport remains specified separately in
+[socket-api-v0.2.0.md](socket-api-v0.2.0.md).
+
+## 1. Scope
+
+The control socket contract covers:
+
+- daemon discovery and access rules
+- request/response framing
+- command families and payload shapes
+- error reporting
+- observability and event streaming
+
+The control socket contract does not cover:
+
+- the device dataplane stream exchanged with simulators
+- kernel-internal APIs used by drivers to create or destroy devices
+- the on-disk format of non-normative daemon debug logs
+
+## 2. Overview
+
+In `v0.2.0`, VirtRTLab exposes one canonical control endpoint:
+
+| Property | Value |
+|---|---|
+| Path | `/run/virtrtlab/control.sock` |
+| Address family | `AF_UNIX` |
+| Socket type | `SOCK_STREAM` |
+| Framing | UTF-8 JSON Lines (`\n`-terminated objects) |
+| Access model | daemon-owned socket, group-accessible to `virtrtlab` |
+
+Each request is one JSON object on one line. Each response is one JSON object on
+one line.
+
+Requests and responses are correlated by a client-supplied `id` field.
+
+## 3. Connection model
+
+### 3.1 Client classes
+
+| Client | Typical use | Allowed operations |
+|---|---|---|
+| `virtrtlabctl` | normal operator and CI control | all documented command families |
+| harness script | fault injection, status polling | `lab.*`, `device.*`, `fault.*`, `sim.*`, and `events.subscribe` when supported |
+| diagnostic tool | read-only inspection | `lab.status`, `device.list`, `device.get`, `device.stats` |
+
+### 3.2 Session rules
+
+| Rule | Required behavior |
+|---|---|
+| Encoding | all frames are UTF-8 JSON text ending with `\n` |
+| Pipelining | allowed; multiple requests may be outstanding on one connection |
+| Ordering | responses may arrive out of submission order; clients must match by `id` |
+| Authentication | based on filesystem permissions of the Unix socket; no in-band login |
+| Backward compatibility | unknown top-level fields must be ignored unless explicitly required by the selected action |
+
+## 4. Base envelope
+
+### 4.1 Request envelope
+
+Every request object uses this base shape:
+
+```json
+{
+  "id": "req-0001",
+  "action": "device.set",
+  "params": {
+    "device": "uart0",
+    "values": {
+      "latency_ns": 500000
+    }
+  }
+}
+```
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `id` | string | yes | opaque request identifier chosen by the client |
+| `action` | string | yes | operation name such as `lab.up` or `fault.inject` |
+| `params` | object | yes | action-specific payload |
+
+### 4.2 Success response envelope
+
+```json
+{
+  "id": "req-0001",
+  "ok": true,
+  "result": {
+    "device": "uart0",
+    "applied": {
+      "latency_ns": 500000
+    }
+  }
+}
+```
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `id` | string | yes | echoed request identifier |
+| `ok` | boolean | yes | `true` on success |
+| `result` | object | yes | action-specific result payload |
+
+### 4.3 Error response envelope
+
+```json
+{
+  "id": "req-0002",
+  "ok": false,
+  "error": {
+    "code": "unknown-device",
+    "message": "unknown device: uart9",
+    "retryable": false,
+    "details": {
+      "device": "uart9"
+    }
+  }
+}
+```
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `id` | string | yes | echoed request identifier |
+| `ok` | boolean | yes | `false` on failure |
+| `error.code` | string | yes | stable machine-readable error code |
+| `error.message` | string | yes | short operator-facing message |
+| `error.retryable` | boolean | yes | whether retry without user correction may succeed |
+| `error.details` | object | no | action-specific structured details |
+
+## 5. Command families
+
+### 5.1 `lab.*`
+
+| Action | Purpose |
+|---|---|
+| `lab.up` | materialize a lab topology from inline counts or a resolved profile |
+| `lab.down` | stop simulators, destroy devices, and return the lab to empty state |
+| `lab.status` | return daemon status, topology summary, and compatibility info |
+| `lab.apply_profile` | replace the current topology and simulator attachment set using one profile payload |
+
+#### `lab.up`
+
+Request example:
+
+```json
+{
+  "id": "req-up-1",
+  "action": "lab.up",
+  "params": {
+    "devices": [
+      {"type": "uart", "count": 2},
+      {"type": "gpio", "count": 1}
+    ],
+    "attachments": [
+      {
+        "device": "uart0",
+        "simulator": "loopback",
+        "auto_start": true,
+        "config": {"delay_ms": 0}
+      }
+    ]
+  }
+}
+```
+
+Success result:
+
+```json
+{
+  "id": "req-up-1",
+  "ok": true,
+  "result": {
+    "state": "up",
+    "devices": [
+      {
+        "name": "uart0",
+        "type": "uart",
+        "aut_path": "/dev/ttyVIRTLAB0",
+        "data_path": "/run/virtrtlab/devices/uart0.sock"
+      },
+      {
+        "name": "uart1",
+        "type": "uart",
+        "aut_path": "/dev/ttyVIRTLAB1",
+        "data_path": "/run/virtrtlab/devices/uart1.sock"
+      },
+      {
+        "name": "gpio0",
+        "type": "gpio",
+        "chip_path": "/dev/gpiochip4",
+        "data_path": "/run/virtrtlab/devices/gpio0.sock"
+      }
+    ],
+    "attachments": [
+      {
+        "device": "uart0",
+        "simulator": "loopback",
+        "state": "running"
+      }
+    ]
+  }
+}
+```
+
+Behavior:
+
+- validates the full requested topology before partial creation
+- creates and destroys devices to match the requested set
+- applies declared attachments after the requested topology exists
+- starts only attachments whose effective `auto_start` is `true`
+
+Validation rules:
+
+- `devices` is required for `lab.up`
+- duplicate `type` entries in one request are invalid
+- `count` must be a positive integer and must not exceed the advertised driver capability limit
+- attachment validation is atomic with topology validation; an invalid attachment prevents any topology mutation
+
+#### `lab.down` result
+
+Illustrative success result:
+
+```json
+{
+  "id": "req-down-1",
+  "ok": true,
+  "result": {
+    "state": "empty",
+    "stopped_simulators": ["uart0"],
+    "destroyed_devices": ["uart0", "uart1", "gpio0"]
+  }
+}
+```
+
+#### `lab.down`
+
+Behavior:
+
+- stops all managed simulators first
+- destroys all VirtRTLab device instances
+- leaves the daemon process itself running unless the service manager stops it separately
+
+#### `lab.status`
+
+Request example:
+
+```json
+{
+  "id": "req-status-1",
+  "action": "lab.status",
+  "params": {}
+}
+```
+
+Success result fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `daemon.state` | string | daemon lab state such as `empty`, `up`, or `error` |
+| `daemon.pid` | integer | daemon process id |
+| `daemon.control_socket` | string | resolved control socket path |
+| `daemon.control_api_version` | string | control API version string |
+| `daemon.control_api_framing` | string | control API framing identifier, initial value `jsonl` |
+| `devices` | array | current device summaries |
+| `simulators` | array | current simulator attachment summaries |
+| `capabilities` | array | driver capability summaries known to the daemon |
+
+`lab.status` is read-only and must not mutate topology or simulator state.
+
+#### `lab.apply_profile`
+
+Request example:
+
+```json
+{
+  "id": "req-apply-1",
+  "action": "lab.apply_profile",
+  "params": {
+    "profile": {
+      "devices": [
+        {"type": "uart", "count": 1},
+        {"type": "gpio", "count": 1}
+      ],
+      "attachments": [
+        {
+          "device": "uart0",
+          "simulator": "loopback",
+          "auto_start": true,
+          "config": {"delay_ms": 0}
+        }
+      ]
+    }
+  }
+}
+```
+
+Rules:
+
+- `lab.apply_profile` replaces the active lab topology with the resolved target profile
+- profile validation is atomic
+- if simulator auto-start is only partially successful after validation, the command returns failure with partial state details, matching the CLI contract
+
+### 5.2 `device.*`
+
+| Action | Purpose |
+|---|---|
+| `device.list` | enumerate current devices and their resolved host paths |
+| `device.create` | add one device instance dynamically |
+| `device.destroy` | remove one device instance dynamically |
+| `device.get` | read device attributes, identity, and resolved paths |
+| `device.set` | update writable device attributes |
+| `device.reset` | apply the device reset contract |
+| `device.stats` | read per-device stats |
+| `device.stats_reset` | reset per-device stats |
+
+#### `device.create`
+
+```json
+{
+  "id": "req-create-1",
+  "action": "device.create",
+  "params": {
+    "type": "uart",
+    "index": 2
+  }
+}
+```
+
+Rules:
+
+- `index` is optional; if omitted, the daemon allocates the lowest free index for that device type
+- creation must fail with `already-exists` if the requested `type + index` tuple already exists
+- creation must fail with `unsupported-device-type` for unknown or unloaded driver classes
+
+Illustrative success result:
+
+```json
+{
+  "id": "req-create-1",
+  "ok": true,
+  "result": {
+    "name": "uart2",
+    "type": "uart",
+    "paths": {
+      "aut_path": "/dev/ttyVIRTLAB2",
+      "data_path": "/run/virtrtlab/devices/uart2.sock",
+      "sysfs_path": "/sys/kernel/virtrtlab/devices/uart2"
+    }
+  }
+}
+```
+
+#### `device.destroy`
+
+Request example:
+
+```json
+{
+  "id": "req-destroy-1",
+  "action": "device.destroy",
+  "params": {
+    "device": "uart2"
+  }
+}
+```
+
+Rules:
+
+- if the target device has an attached simulator, the daemon must stop or detach it before destruction completes
+- destroying an unknown device returns `unknown-device`
+- successful destroy removes the device from subsequent `device.list` results immediately
+
+#### `device.list`
+
+Request example:
+
+```json
+{
+  "id": "req-list-1",
+  "action": "device.list",
+  "params": {}
+}
+```
+
+Success result shape:
+
+```json
+{
+  "id": "req-list-1",
+  "ok": true,
+  "result": {
+    "devices": [
+      {
+        "name": "gpio0",
+        "type": "gpio",
+        "state": "up",
+        "paths": {
+          "chip_path": "/dev/gpiochip4",
+          "data_path": "/run/virtrtlab/devices/gpio0.sock",
+          "sysfs_path": "/sys/kernel/virtrtlab/devices/gpio0"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### `device.get`
+
+Request example:
+
+```json
+{
+  "id": "req-get-1",
+  "action": "device.get",
+  "params": {
+    "device": "gpio0"
+  }
+}
+```
+
+Success result fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | device name |
+| `type` | string | device type |
+| `state` | string | current lifecycle state |
+| `paths` | object | resolved AUT, dataplane, and sysfs paths |
+| `attrs` | object | current control-plane-visible attributes |
+| `stats` | object | current per-device stats counters |
+
+#### `device.set`
+
+```json
+{
+  "id": "req-set-1",
+  "action": "device.set",
+  "params": {
+    "device": "gpio0",
+    "values": {
+      "enabled": true,
+      "latency_ns": 100000,
+      "drop_rate_ppm": 1000
+    }
+  }
+}
+```
+
+Rules:
+
+- all field validation is atomic per request: if one value is invalid, none are applied
+- unknown writable keys return `unknown-attribute`
+- read-only keys return `read-only-attribute`
+
+Success result:
+
+- returns the applied attribute set and the resulting current values for those keys
+
+#### `device.reset`
+
+Request example:
+
+```json
+{
+  "id": "req-reset-1",
+  "action": "device.reset",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- applies the type-specific reset baseline defined by the driver contract
+- does not rename the device or change its index
+- returns the resulting current attrs and stats snapshot after reset
+
+#### `device.stats`
+
+Request example:
+
+```json
+{
+  "id": "req-stats-1",
+  "action": "device.stats",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Success result:
+
+- returns one `stats` object for the target device
+- counter names and units are type-specific and must match the driver contract
+
+#### `device.stats_reset`
+
+Request example:
+
+```json
+{
+  "id": "req-stats-reset-1",
+  "action": "device.stats_reset",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- resets only the target device counters
+- returns the post-reset `stats` object
+- does not modify non-stat attributes
+
+### 5.3 `fault.*`
+
+| Action | Purpose |
+|---|---|
+| `fault.inject` | inject an immediate one-shot event on a device |
+| `fault.profile_apply` | apply a named or inline fault profile to a device |
+| `fault.profile_clear` | remove an applied named profile from a device |
+
+#### `fault.inject`
+
+GPIO example:
+
+```json
+{
+  "id": "req-inject-1",
+  "action": "fault.inject",
+  "params": {
+    "device": "gpio0",
+    "kind": "line-write",
+    "payload": {
+      "line": 0,
+      "value": 1
+    }
+  }
+}
+```
+
+UART example:
+
+```json
+{
+  "id": "req-inject-2",
+  "action": "fault.inject",
+  "params": {
+    "device": "uart0",
+    "kind": "rx-bytes",
+    "payload": {
+      "encoding": "base64",
+      "data": "AQIDBA=="
+    }
+  }
+}
+```
+
+Rules:
+
+- supported `kind` values are device-type specific and defined by the driver contract
+- payload validation is strict; malformed or unsupported fields return `invalid-payload`
+- one-shot injection does not implicitly modify persistent fault attributes unless the selected injection kind says so explicitly
+
+#### `fault.profile_apply`
+
+`fault.profile_apply` is part of the `v0.2.0` minimum control-plane contract.
+
+Named-profile example:
+
+```json
+{
+  "id": "req-profile-1",
+  "action": "fault.profile_apply",
+  "params": {
+    "device": "uart0",
+    "profile": {
+      "name": "slow-noisy-uart"
+    }
+  }
+}
+```
+
+Inline-profile example:
+
+```json
+{
+  "id": "req-profile-2",
+  "action": "fault.profile_apply",
+  "params": {
+    "device": "gpio0",
+    "profile": {
+      "inline": {
+        "enabled": true,
+        "latency_ns": 100000,
+        "jitter_ns": 10000,
+        "drop_rate_ppm": 1000,
+        "bitflip_rate_ppm": 0
+      }
+    }
+  }
+}
+```
+
+Rules:
+
+- exactly one of `profile.name` or `profile.inline` must be present
+- inline profile validation follows the same type and range rules as `device.set`
+- named profile resolution is daemon-defined but must be deterministic for one daemon configuration
+- a successful apply returns the effective persistent fault state visible on the target device
+
+#### `fault.profile_clear`
+
+```json
+{
+  "id": "req-profile-clear-1",
+  "action": "fault.profile_clear",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- clears the currently applied named or inline profile from the target device
+- returns the resulting persistent fault state after clear
+
+Result fields for both `fault.profile_apply` and `fault.profile_clear`:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `device` | string | target device name |
+| `profile` | object or `null` | effective applied profile metadata, or `null` after clear |
+| `effective_attrs` | object | resulting persistent fault attrs now active on the device |
+
+### 5.4 `sim.*`
+
+| Action | Purpose |
+|---|---|
+| `sim.list` | list visible simulator catalog entries |
+| `sim.inspect` | inspect one simulator catalog entry |
+| `sim.attach` | attach a simulator definition to one device |
+| `sim.detach` | detach the simulator from one device |
+| `sim.start` | start the attached simulator process |
+| `sim.stop` | stop the attached simulator process |
+| `sim.status` | inspect aggregate or per-device simulator lifecycle state |
+
+`sim.*` behavior is normatively aligned with
+[simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md) and
+[virtrtlabctl-v0.2.0.md](virtrtlabctl-v0.2.0.md).
+
+#### `sim.list`
+
+Request example:
+
+```json
+{
+  "id": "req-sim-list-1",
+  "action": "sim.list",
+  "params": {
+    "type": "uart",
+    "verbose": false
+  }
+}
+```
+
+Rules:
+
+- `type` is optional and filters visible catalog entries by supported device type
+- `verbose` is optional and defaults to `false`
+- `sim.list` is read-only and must not mutate runtime state
+
+Success result minimum fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `simulators` | array | visible catalog entries after precedence resolution |
+
+Each simulator summary contains at least `name`, `version`, `supports`, and
+`summary`. When `verbose = true`, each summary also contains `catalog_file` and
+`overrides`.
+
+#### `sim.inspect`
+
+Request example:
+
+```json
+{
+  "id": "req-sim-inspect-1",
+  "action": "sim.inspect",
+  "params": {
+    "name": "loopback",
+    "version": "1.0.0"
+  }
+}
+```
+
+Rules:
+
+- `name` is required
+- `version` is optional only when exactly one visible catalog entry exists for that simulator name
+- ambiguity without `version` returns `ambiguous-simulator-version` with structured details
+
+Success result minimum fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | simulator name |
+| `version` | string | selected simulator version |
+| `supports` | array | supported device kinds |
+| `summary` | string | one-line description |
+| `catalog_file` | string | resolved catalog entry path |
+| `restart_policy` | string | declared restart policy |
+
+If declared, `description` and `parameters` are included with the same meaning
+as in the simulator contract.
+
+#### `sim.attach`
+
+Request example:
+
+```json
+{
+  "id": "req-sim-attach-1",
+  "action": "sim.attach",
+  "params": {
+    "device": "uart0",
+    "simulator": "loopback",
+    "version": "1.0.0",
+    "auto_start": false,
+    "config": {
+      "delay_ms": 5
+    }
+  }
+}
+```
+
+Rules:
+
+- the target device must already exist
+- the selected simulator must support the target device type
+- if multiple visible versions share the selected simulator name and `version` is omitted, the request returns `ambiguous-simulator-version`
+- a second `sim.attach` on the same device replaces the existing attachment only when the current attachment state is `attached`, `stopped`, or `failed`
+- replacement while the current attachment is `starting`, `running`, or `stopping` returns `state-conflict`
+- successful attach creates or refreshes the daemon-owned runtime attachment state for that device
+
+Success result minimum fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `device` | string | target device |
+| `simulator` | string | attached simulator name |
+| `version` | string | selected simulator version |
+| `state` | string | resulting attachment lifecycle state, initially `attached` |
+| `auto_start` | boolean | effective attachment auto-start policy |
+
+#### `sim.detach`
+
+Request example:
+
+```json
+{
+  "id": "req-sim-detach-1",
+  "action": "sim.detach",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- if the attachment is running, the daemon stops it first
+- successful detach removes the per-device runtime attachment directory
+- detaching a non-attached device returns `not-attached`; an absent device returns `unknown-device`
+
+Success result minimum fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `device` | string | target device |
+| `state` | string | resulting state, always `detached` |
+
+#### `sim.start`
+
+Request example:
+
+```json
+{
+  "id": "req-sim-start-1",
+  "action": "sim.start",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- the target device must exist and have an attached simulator
+- `sim.start` on a `running` or `starting` attachment returns `state-conflict`
+- successful start returns the attachment state after immediate launch checks
+- no simulator-specific readiness probe is required by the `v0.2.0` base contract
+
+Success result minimum fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `device` | string | target device |
+| `simulator` | string | running simulator name |
+| `version` | string | selected simulator version |
+| `state` | string | resulting lifecycle state |
+| `pid` | integer or `null` | simulator process id when available |
+
+#### `sim.stop`
+
+Request example:
+
+```json
+{
+  "id": "req-sim-stop-1",
+  "action": "sim.stop",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- the target device must exist and have an attachment
+- if the attachment state is already `stopped`, the daemon returns success with the unchanged `stopped` snapshot
+- `sim.stop` on an `attached` or `failed` attachment returns `state-conflict`
+- graceful termination is attempted first
+- if the process does not exit within the bounded timeout, the daemon may force termination and still return success if the process is observed dead afterward
+
+Success result minimum fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `device` | string | target device |
+| `state` | string | resulting lifecycle state, normally `stopped` |
+| `last_exit_code` | integer or `null` | latest observed terminal exit code |
+
+#### `sim.status`
+
+Request example without device:
+
+```json
+{
+  "id": "req-sim-status-1",
+  "action": "sim.status",
+  "params": {}
+}
+```
+
+Request example with device:
+
+```json
+{
+  "id": "req-sim-status-2",
+  "action": "sim.status",
+  "params": {
+    "device": "uart0"
+  }
+}
+```
+
+Rules:
+
+- without `device`, returns aggregate attachment summaries
+- with `device`, returns one coherent per-device snapshot
+- if the device exists but no attachment exists, returns `not-attached` with details identifying the unattached device
+
+Success result minimum fields for aggregate status:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `attachments` | array | zero or more attachment summaries |
+
+Each attachment summary contains at least `device`, `state`, `simulator`,
+`simulator_version`, `pid`, `auto_start`, and `updated_at`.
+
+Success result minimum fields for per-device status:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `device` | string | target device |
+| `device_type` | string | device kind |
+| `simulator` | string | simulator name |
+| `simulator_version` | string | selected simulator version |
+| `state` | string | attachment lifecycle state |
+| `auto_start` | boolean | effective auto-start policy |
+| `restart_policy` | string | effective restart policy |
+| `pid` | integer or `null` | simulator process id when alive |
+
+#### `sim.logs`
+
+`sim.logs` is not part of the control-socket request/response contract in `v0.2.0`.
+
+Rules:
+
+- log streaming remains a CLI-level operation over daemon-owned runtime log files
+- the control socket may expose metadata needed by `sim.status`, but it does not need to proxy log lines in `v0.2.0`
+
+### 5.5 `events.subscribe`
+
+`events.subscribe` is optional in `v0.2.0`.
+
+The daemon may support event streaming on the same connection.
+
+Subscription request:
+
+```json
+{
+  "id": "req-sub-1",
+  "action": "events.subscribe",
+  "params": {
+    "topics": ["lab", "device", "sim"]
+  }
+}
+```
+
+After the normal success response, the daemon may emit unsolicited event objects
+on the same connection.
+
+Event example:
+
+```json
+{
+  "event": "device-added",
+  "topic": "device",
+  "sequence": 17,
+  "payload": {
+    "device": "uart2",
+    "type": "uart"
+  }
+}
+```
+
+Event rules:
+
+- event objects do not contain `id`
+- `sequence` is monotonically increasing per daemon instance
+- event delivery is best-effort; clients must resynchronize with explicit read commands after reconnect
+- clients must not depend on `events.subscribe` as the only way to observe state changes
+
+## 6. Error codes
+
+The following `error.code` values are stable in `v0.2.0`:
+
+| Code | Meaning |
+|---|---|
+| `invalid-request` | malformed JSON, missing required fields, or wrong top-level types |
+| `unknown-action` | unsupported `action` name |
+| `permission-denied` | caller lacks permission for the operation |
+| `unknown-device` | referenced device does not exist |
+| `unknown-simulator` | referenced simulator does not exist |
+| `unsupported-device-type` | no driver contract exists for the requested device type |
+| `already-exists` | requested object already exists |
+| `state-conflict` | operation is invalid in the current lifecycle state |
+| `unknown-attribute` | write attempted on an unknown key |
+| `read-only-attribute` | write attempted on a read-only key |
+| `invalid-value` | attribute value failed range or type validation |
+| `invalid-payload` | injection or structured request payload failed validation |
+| `kernel-failure` | daemon could not complete the requested kernel-side operation |
+| `simulator-failure` | simulator process launch or stop failed |
+| `not-attached` | simulator lifecycle action referenced an existing device without an attachment |
+| `ambiguous-simulator-version` | simulator name matched multiple visible versions without explicit selection |
+
+Recommended action-specific error mapping:
+
+| Action | Condition | Error code |
+|---|---|---|
+| `lab.up` | duplicate device type entry in one request | `invalid-request` |
+| `lab.up` | requested count exceeds driver capability | `invalid-value` |
+| `device.create` | requested `type + index` already exists | `already-exists` |
+| `device.destroy` | target absent | `unknown-device` |
+| `device.get` | target absent | `unknown-device` |
+| `device.set` | one or more invalid values | `invalid-value` |
+| `device.stats_reset` | target absent | `unknown-device` |
+| `fault.inject` | unknown injection kind for device type | `invalid-payload` |
+| `sim.inspect` | ambiguous simulator version | `ambiguous-simulator-version` |
+| `sim.attach` | ambiguous simulator version | `ambiguous-simulator-version` |
+| `sim.attach` | simulator unsupported for device type | `invalid-request` |
+| `sim.detach` | device has no attachment | `not-attached` |
+| `sim.start` | device has no attachment | `not-attached` |
+| `sim.start` | attachment already `running` or `starting` | `state-conflict` |
+| `sim.stop` | attachment absent | `not-attached` |
+| `sim.stop` | attachment exists but is not live and not `stopped` | `state-conflict` |
+| `sim.status` with `device` | device exists but attachment absent | `not-attached` |
+
+## 7. Versioning
+
+The daemon exposes its control API version through `lab.status`.
+
+Illustrative `lab.status` daemon fragment:
+
+```json
+{
+  "daemon": {
+    "control_socket": "/run/virtrtlab/control.sock",
+    "control_api_version": "0.2.0",
+    "control_api_framing": "jsonl"
+  }
+}
+```
+
+Compatibility rules:
+
+- `v0.2.x` clients must ignore unknown result fields
+- breaking control-plane changes require a new versioned specification document
+
+## 8. Rationale
+
+**Why one canonical control socket?**  
+It centralizes authorization, state validation, and lifecycle sequencing in one
+daemon instead of spreading control across `sysfs`, `sudo`, and ad hoc shell
+wrappers.
+
+**Why JSON Lines over a Unix stream socket?**  
+It keeps the protocol easy to debug with ordinary tooling while still supporting
+long-lived connections and future event streaming.
+
+**Why keep data and control separate?**  
+The device dataplane stays tool-friendly and device-oriented, while
+the control plane gains structured validation and explicit errors.
+
+## 9. Decisions
+
+- `fault.profile_apply` and `fault.profile_clear` are part of the `v0.2.0`
+  minimum control-plane contract
+- `events.subscribe` remains optional in `v0.2.0`; polling through read-side
+  actions such as `lab.status`, `device.get`, and `sim.status` remains the
+  required interoperability path

--- a/docs/v0.2.0/daemon-config-v0.2.0.md
+++ b/docs/v0.2.0/daemon-config-v0.2.0.md
@@ -38,6 +38,9 @@ Canonical search order:
 
 If the selected config file exists but is malformed, daemon startup fails.
 
+Configuration snippets in this document are illustrative examples. Normative
+requirements are defined by the key tables and rule lists that accompany them.
+
 ## 3. Top-level sections
 
 The following top-level sections are defined in `v0.2.0`:
@@ -65,14 +68,17 @@ simulator_dir = "/run/virtrtlab/simulators"
 |---|---|---|---|
 | `root_dir` | string | `/run/virtrtlab` | base runtime directory |
 | `pid_file` | string | `/run/virtrtlab/virtrtlabd.pid` | daemon pid file path |
-| `state_dir` | string | `/run/virtrtlab/state` | daemon-owned state directory |
-| `simulator_dir` | string | `/run/virtrtlab/simulators` | simulator runtime-state root |
+| `state_dir` | string | `/run/virtrtlab/state` | daemon-owned aggregate state directory for non-simulator runtime metadata |
+| `simulator_dir` | string | `/run/virtrtlab/simulators` | per-attachment simulator runtime-state and log root |
 
 Rules:
 
 - relative paths are not allowed
 - all configured paths must remain within one local filesystem namespace visible to the daemon
 - startup fails if the daemon cannot create or access the configured runtime paths
+- clients and companion documents must treat these paths as resolved runtime values,
+  not as immutable hard-coded locations
+- `state_dir` and `simulator_dir` are intentionally distinct so simulator lifecycle files do not become the implicit storage location for unrelated daemon runtime state
 
 ## 5. Control section
 
@@ -120,6 +126,8 @@ Rules:
 - `transport = "unix"` is the only required dataplane transport in `v0.2.0`
 - `{device}` expands to the canonical VirtRTLab device name such as `uart0` or `gpio0`
 - the daemon must expose the resolved dataplane path through the control plane for every device that supports a data socket
+- examples under `/run/virtrtlab/...` are the default installed layout, not the
+	only valid deployed layout
 
 Illustrative resolved paths:
 
@@ -193,3 +201,7 @@ One common `{device}.sock` naming rule is sufficient in `v0.2.0`.
 
 Per-device-type dataplane naming templates are out of scope for the first
 release and may be introduced only if a concrete deployment need appears.
+
+The runtime paths defined in this document are normative deployment outputs for
+the daemon and simulator lifecycle surfaces they govern. They do not create a
+second topology API beyond the control socket.

--- a/docs/v0.2.0/daemon-config-v0.2.0.md
+++ b/docs/v0.2.0/daemon-config-v0.2.0.md
@@ -1,0 +1,195 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# virtrtlabd Configuration (v0.2.0 Draft)
+
+This document defines the external configuration contract of `virtrtlabd` in
+`v0.2.0`.
+
+It exists because the daemon now owns the control plane, device dataplane
+socket layout, runtime-state files, and simulator lifecycle behavior. Those
+surfaces require deployment-time configuration that should not be hard-coded.
+
+## 1. Scope
+
+The daemon configuration contract covers:
+
+- configuration file presence and format
+- configurable filesystem paths
+- logging configuration
+- transport-selection policy for the control and dataplane sockets
+
+It does not cover:
+
+- per-device simulator catalog metadata
+- lab profile content
+- kernel driver capability discovery
+
+## 2. Format and location
+
+In `v0.2.0`, the daemon configuration format is **TOML**.
+
+Canonical search order:
+
+| Precedence | Path | Purpose |
+|---|---|---|
+| 1 | explicit `--config <path>` CLI argument | operator-selected daemon config |
+| 2 | `/etc/virtrtlab/virtrtlabd.toml` | installed system-wide daemon config |
+| 3 | built-in defaults | no external file present |
+
+If the selected config file exists but is malformed, daemon startup fails.
+
+## 3. Top-level sections
+
+The following top-level sections are defined in `v0.2.0`:
+
+| Section | Purpose |
+|---|---|
+| `[runtime]` | runtime directory, pid file, and state-file placement |
+| `[control]` | control-socket transport and path |
+| `[dataplane]` | per-device data-socket defaults |
+| `[logging]` | daemon log behavior |
+
+## 4. Runtime section
+
+Illustrative example:
+
+```toml
+[runtime]
+root_dir = "/run/virtrtlab"
+pid_file = "/run/virtrtlab/virtrtlabd.pid"
+state_dir = "/run/virtrtlab/state"
+simulator_dir = "/run/virtrtlab/simulators"
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `root_dir` | string | `/run/virtrtlab` | base runtime directory |
+| `pid_file` | string | `/run/virtrtlab/virtrtlabd.pid` | daemon pid file path |
+| `state_dir` | string | `/run/virtrtlab/state` | daemon-owned state directory |
+| `simulator_dir` | string | `/run/virtrtlab/simulators` | simulator runtime-state root |
+
+Rules:
+
+- relative paths are not allowed
+- all configured paths must remain within one local filesystem namespace visible to the daemon
+- startup fails if the daemon cannot create or access the configured runtime paths
+
+## 5. Control section
+
+Illustrative example:
+
+```toml
+[control]
+transport = "unix"
+socket_path = "/run/virtrtlab/control.sock"
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `transport` | string | `unix` | control-plane transport kind |
+| `socket_path` | string | `/run/virtrtlab/control.sock` | Unix-socket path when `transport = "unix"` |
+
+`transport` allowed values in `v0.2.0`:
+
+| Value | Status |
+|---|---|
+| `unix` | required and normative |
+
+No network transport is part of the `v0.2.0` base contract. Future revisions may
+add additional transport kinds, but `unix` remains the only mandatory one.
+
+## 6. Dataplane section
+
+Illustrative example:
+
+```toml
+[dataplane]
+transport = "unix"
+socket_dir = "/run/virtrtlab/devices"
+name_pattern = "{device}.sock"
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `transport` | string | `unix` | dataplane transport kind |
+| `socket_dir` | string | `/run/virtrtlab/devices` | directory for per-device dataplane sockets |
+| `name_pattern` | string | `{device}.sock` | socket file naming template |
+
+Rules:
+
+- `transport = "unix"` is the only required dataplane transport in `v0.2.0`
+- `{device}` expands to the canonical VirtRTLab device name such as `uart0` or `gpio0`
+- the daemon must expose the resolved dataplane path through the control plane for every device that supports a data socket
+
+Illustrative resolved paths:
+
+| Device | Result |
+|---|---|
+| `uart0` | `/run/virtrtlab/devices/uart0.sock` |
+| `gpio0` | `/run/virtrtlab/devices/gpio0.sock` |
+
+## 7. Logging section
+
+Illustrative example:
+
+```toml
+[logging]
+destination = "journald"
+level = "info"
+stderr = false
+```
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `destination` | string | `journald` | primary logging backend |
+| `level` | string | `info` | minimum emitted severity |
+| `stderr` | bool | `false` | whether to mirror logs to stderr |
+
+Allowed `destination` values in `v0.2.0`:
+
+| Value | Meaning |
+|---|---|
+| `journald` | systemd journal or syslog-compatible service-manager sink |
+| `stderr` | foreground process stderr |
+
+Allowed `level` values:
+
+`debug`, `info`, `warn`, `error`
+
+## 8. Minimal example
+
+```toml
+[runtime]
+root_dir = "/run/virtrtlab"
+
+[control]
+transport = "unix"
+socket_path = "/run/virtrtlab/control.sock"
+
+[dataplane]
+transport = "unix"
+socket_dir = "/run/virtrtlab/devices"
+name_pattern = "{device}.sock"
+
+[logging]
+destination = "journald"
+level = "info"
+stderr = false
+```
+
+## 9. Rationale
+
+**Why add a daemon config file now?**  
+The daemon is no longer a trivial relay process. Runtime paths, socket layout,
+and logging behavior are deployment concerns that need a documented contract.
+
+**Why keep Unix sockets mandatory in `v0.2.0`?**  
+They provide the simplest local security model and keep the control plane out of
+scope of network exposure concerns for the first hotplug-capable release.
+
+## 10. Decision
+
+One common `{device}.sock` naming rule is sufficient in `v0.2.0`.
+
+Per-device-type dataplane naming templates are out of scope for the first
+release and may be introduced only if a concrete deployment need appears.

--- a/docs/v0.2.0/daemon-config-v0.2.0.md
+++ b/docs/v0.2.0/daemon-config-v0.2.0.md
@@ -127,7 +127,7 @@ Rules:
 - `{device}` expands to the canonical VirtRTLab device name such as `uart0` or `gpio0`
 - the daemon must expose the resolved dataplane path through the control plane for every device that supports a data socket
 - examples under `/run/virtrtlab/...` are the default installed layout, not the
-	only valid deployed layout
+  only valid deployed layout
 
 Illustrative resolved paths:
 

--- a/docs/v0.2.0/daemon-v0.2.0.md
+++ b/docs/v0.2.0/daemon-v0.2.0.md
@@ -23,7 +23,7 @@ The daemon is responsible for all of the following:
 |---|---|---|
 | Control socket | resolved daemon control-socket path; default installed path `/run/virtrtlab/control.sock` | structured control-plane requests and responses |
 | Device data socket | resolved per-device dataplane path; default installed pattern `/run/virtrtlab/devices/<device>.sock` | simulator dataplane for one device |
-| Runtime root | resolved daemon runtime root; default installed path `/run/virtrtlab/` | daemon-owned state, pid files, sockets, simulator runtime metadata |
+| Runtime root | resolved daemon runtime root; default installed path `/run/virtrtlab` | daemon-owned state, pid files, sockets, simulator runtime metadata |
 
 The device dataplane contract remains separately specified in
 [socket-api-v0.2.0.md](socket-api-v0.2.0.md).

--- a/docs/v0.2.0/daemon-v0.2.0.md
+++ b/docs/v0.2.0/daemon-v0.2.0.md
@@ -1,0 +1,149 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# virtrtlabd (v0.2.0 Draft)
+
+This document defines the `v0.2.0` daemon contract.
+
+In `v0.2.0`, `virtrtlabd` is no longer only a UART relay daemon. It becomes the
+authoritative userspace control-plane process for VirtRTLab.
+
+## 1. Responsibilities
+
+The daemon is responsible for all of the following:
+
+- exposing the canonical control socket
+- materializing and destroying VirtRTLab device instances on demand
+- managing the per-device dataplane sockets and the type-specific relay logic they require
+- supervising simulator attachments and process lifecycle
+- exporting lab status to CLI and CI clients
+
+## 2. Runtime endpoints
+
+| Endpoint | Path | Purpose |
+|---|---|---|
+| Control socket | `/run/virtrtlab/control.sock` | structured control-plane requests and responses |
+| Device data socket | `/run/virtrtlab/devices/<device>.sock` | simulator dataplane for one device |
+| Runtime root | `/run/virtrtlab/` | daemon-owned state, pid files, sockets, simulator runtime metadata |
+
+The device dataplane contract remains separately specified in
+[socket-api-v0.2.0.md](socket-api-v0.2.0.md).
+
+The control protocol is specified in
+[control-socket-v0.2.0.md](control-socket-v0.2.0.md).
+
+The daemon configuration contract is specified in
+[daemon-config-v0.2.0.md](daemon-config-v0.2.0.md).
+
+## 3. Lifecycle
+
+### 3.1 Daemon process lifecycle
+
+| Phase | Required behavior |
+|---|---|
+| startup | load configuration, create or validate `/run/virtrtlab/`, bind the control socket, load driver capability inventory, and begin serving requests |
+| steady state | accept concurrent control clients, maintain current topology, drive per-device dataplanes, monitor simulator processes |
+| shutdown | stop managed simulators, close sockets, destroy only the runtime state implied by the requested shutdown mode |
+
+### 3.2 Lab lifecycle
+
+The daemon maintains one lab state machine.
+
+| State | Meaning |
+|---|---|
+| `empty` | no VirtRTLab device instances are materialized |
+| `configuring` | topology change is in progress |
+| `up` | one or more devices exist and the control plane is operational |
+| `tearing-down` | destruction is in progress |
+| `error` | the daemon detected an operational failure that requires operator attention |
+
+## 4. Concurrency rules
+
+| Rule | Required behavior |
+|---|---|
+| topology mutation serialization | only one topology-changing operation (`lab.up`, `lab.down`, `device.create`, `device.destroy`, `lab.apply_profile`) may commit at a time |
+| read operations | multiple read-only requests may run concurrently |
+| fault injection | may run concurrently with read operations and active AUT traffic for the target device |
+| simulator lifecycle | per-device simulator state transitions are serialized per device |
+
+## 5. Data plane separation
+
+The daemon must preserve a strict separation between:
+
+| Plane | Interface | Payload |
+|---|---|---|
+| control plane | `/run/virtrtlab/control.sock` | JSON requests/responses/events |
+| device data plane | `/run/virtrtlab/devices/<device>.sock` | device-specific dataplane payload |
+
+The daemon must not multiplex dataplane payloads inside the control socket.
+
+## 6. Status model
+
+The daemon exposes status through `lab.status` and related control actions.
+
+Illustrative result:
+
+```json
+{
+  "daemon": {
+    "state": "up",
+    "pid": 2841,
+    "control_socket": "/run/virtrtlab/control.sock",
+    "control_api_version": "0.2.0"
+  },
+  "devices": [
+    {"name": "uart0", "type": "uart"},
+    {"name": "gpio0", "type": "gpio"}
+  ],
+  "simulators": [
+    {"device": "uart0", "simulator": "loopback", "state": "running"}
+  ]
+}
+```
+
+## 7. Logging
+
+The daemon may log to stderr, syslog, or journald according to deployment.
+
+The only normative logging requirement in `v0.2.0` is that operator-visible
+control-plane failures remain queryable through control responses and simulator
+state inspection. Log formatting itself is not the external contract.
+
+## 8. Failure behavior
+
+| Failure class | Required observable behavior |
+|---|---|
+| malformed client request | reject that request with `invalid-request`; keep the connection open unless framing is unrecoverable |
+| topology change failure | report structured error; keep previous stable topology visible |
+| simulator crash | update simulator state to `failed`; if subscribed clients exist, emit a `simulator-state-changed` event |
+| control socket bind failure | daemon startup fails |
+| device dataplane socket bind or driver-side open failure for one device | corresponding create or up operation fails for that device; previously running devices remain unchanged unless the requested operation was all-or-nothing |
+
+## 9. Service-manager integration
+
+The daemon contract assumes a service manager or equivalent launch mechanism is
+used in normal installations.
+
+Required outcomes:
+
+- the daemon starts automatically or on operator demand without interactive `sudo`
+- the daemon keeps a stable control socket path across restarts
+- runtime directory ownership and modes satisfy
+  [privilege-model-v0.2.0.md](privilege-model-v0.2.0.md)
+
+## 10. Rationale
+
+**Why make the daemon authoritative?**  
+It gives VirtRTLab one state coordinator for dynamic topology, simulator
+attachment, and fault control, which is necessary once devices become hotpluggable.
+
+**Why keep a simulator-facing dataplane?**  
+The existing UART byte-stream design is still useful, and the same separation
+now extends naturally to other device classes such as GPIO. `v0.2.0` extends
+the daemon instead of replacing the transport model.
+
+## 11. Decisions
+
+- `lab.down` destroys all active device instances and stops managed simulators,
+  but does not stop the daemon process itself
+- aggregate and per-device runtime state files under `/run/virtrtlab/` remain
+  part of the normative contract in `v0.2.0`

--- a/docs/v0.2.0/daemon-v0.2.0.md
+++ b/docs/v0.2.0/daemon-v0.2.0.md
@@ -21,9 +21,9 @@ The daemon is responsible for all of the following:
 
 | Endpoint | Path | Purpose |
 |---|---|---|
-| Control socket | `/run/virtrtlab/control.sock` | structured control-plane requests and responses |
-| Device data socket | `/run/virtrtlab/devices/<device>.sock` | simulator dataplane for one device |
-| Runtime root | `/run/virtrtlab/` | daemon-owned state, pid files, sockets, simulator runtime metadata |
+| Control socket | resolved daemon control-socket path; default installed path `/run/virtrtlab/control.sock` | structured control-plane requests and responses |
+| Device data socket | resolved per-device dataplane path; default installed pattern `/run/virtrtlab/devices/<device>.sock` | simulator dataplane for one device |
+| Runtime root | resolved daemon runtime root; default installed path `/run/virtrtlab/` | daemon-owned state, pid files, sockets, simulator runtime metadata |
 
 The device dataplane contract remains separately specified in
 [socket-api-v0.2.0.md](socket-api-v0.2.0.md).
@@ -40,9 +40,9 @@ The daemon configuration contract is specified in
 
 | Phase | Required behavior |
 |---|---|
-| startup | load configuration, create or validate `/run/virtrtlab/`, bind the control socket, load driver capability inventory, and begin serving requests |
+| startup | load configuration, create or validate the configured runtime root, bind the resolved control socket, load driver capability inventory, and begin serving requests |
 | steady state | accept concurrent control clients, maintain current topology, drive per-device dataplanes, monitor simulator processes |
-| shutdown | stop managed simulators, close sockets, destroy only the runtime state implied by the requested shutdown mode |
+| shutdown | stop managed simulators, close sockets, and destroy only the runtime state owned by the active daemon instance |
 
 ### 3.2 Lab lifecycle
 
@@ -71,8 +71,8 @@ The daemon must preserve a strict separation between:
 
 | Plane | Interface | Payload |
 |---|---|---|
-| control plane | `/run/virtrtlab/control.sock` | JSON requests/responses/events |
-| device data plane | `/run/virtrtlab/devices/<device>.sock` | device-specific dataplane payload |
+| control plane | resolved daemon control-socket path; default installed path `/run/virtrtlab/control.sock` | JSON requests/responses/events |
+| device data plane | resolved per-device dataplane path; default installed pattern `/run/virtrtlab/devices/<device>.sock` | device-specific dataplane payload |
 
 The daemon must not multiplex dataplane payloads inside the control socket.
 
@@ -116,7 +116,7 @@ state inspection. Log formatting itself is not the external contract.
 | topology change failure | report structured error; keep previous stable topology visible |
 | simulator crash | update simulator state to `failed`; if subscribed clients exist, emit a `simulator-state-changed` event |
 | control socket bind failure | daemon startup fails |
-| device dataplane socket bind or driver-side open failure for one device | corresponding create or up operation fails for that device; previously running devices remain unchanged unless the requested operation was all-or-nothing |
+| device dataplane socket bind or driver-side open failure for one device | corresponding create or up operation fails for that device; topology and partial auto-start outcomes follow the control-socket contract for `device.create`, `lab.up`, and `lab.apply_profile` |
 
 ## 9. Service-manager integration
 
@@ -145,5 +145,7 @@ the daemon instead of replacing the transport model.
 
 - `lab.down` destroys all active device instances and stops managed simulators,
   but does not stop the daemon process itself
-- aggregate and per-device runtime state files under `/run/virtrtlab/` remain
-  part of the normative contract in `v0.2.0`
+- aggregate and per-device simulator runtime state files under the configured
+  simulator runtime root remain part of the normative simulator-observability
+  contract in `v0.2.0`; they do not replace the control socket as the topology
+  control API

--- a/docs/v0.2.0/driver-contract-v0.2.0.md
+++ b/docs/v0.2.0/driver-contract-v0.2.0.md
@@ -144,6 +144,10 @@ Required minimum read-side attributes:
 | `stats/` | ro subtree | per-device counters |
 | `stats/reset` | wo compatibility entry | writing `1` resets the same counters as `device.stats_reset`; any other value is invalid |
 
+Illustrative invalid `stats/reset` write outcome:
+
+- writing `0`, `2`, or any non-integer text to `stats/reset` fails with the same invalid-value behavior as the control-plane `device.stats_reset` compatibility surface expects
+
 Additional read-only attributes are device-specific.
 
 ### 6.2 Writable sysfs
@@ -187,6 +191,10 @@ Common persistent-attribute range rules:
 
 If a driver imposes a lower implementation maximum for `latency_ns` or
 `jitter_ns`, values above that maximum must fail with `invalid-value`.
+
+When these implementation maxima are bounded, they must be discoverable through
+the driver capability object so clients can validate requests without relying
+on trial-and-error writes.
 
 ### 7.3 Reset
 
@@ -250,6 +258,8 @@ Normative capability fields:
 | `hotplug` | boolean | runtime create/destroy supported |
 | `max_devices` | integer or `null` | implementation maximum, if bounded |
 | `line_count` | integer or `null` | physical line count for line-oriented devices, else `null` |
+| `latency_ns_max` | integer or `null` | maximum accepted `latency_ns` value when bounded, else `null` |
+| `jitter_ns_max` | integer or `null` | maximum accepted `jitter_ns` value when bounded, else `null` |
 | `persistent_attrs` | array of strings | writable attr names accepted by `device.set` |
 | `injection_kinds` | array of strings | supported `fault.inject` kinds |
 | `path_keys` | array of strings | path keys returned by `device.get` |
@@ -262,6 +272,8 @@ Illustrative capability object:
   "hotplug": true,
   "max_devices": 32,
   "line_count": 8,
+  "latency_ns_max": 1000000000,
+  "jitter_ns_max": 1000000000,
   "persistent_attrs": [
     "enabled",
     "latency_ns",
@@ -273,6 +285,13 @@ Illustrative capability object:
   "path_keys": ["chip_path", "data_path", "sysfs_path"]
 }
 ```
+
+Rules:
+
+- if a driver accepts `latency_ns` or `jitter_ns`, it should expose the
+  corresponding maximum through `latency_ns_max` and `jitter_ns_max`
+- if the driver has no practical bound beyond the accepted integer type, the
+  field may be `null`
 
 ## 10. Driver-specific obligations
 

--- a/docs/v0.2.0/driver-contract-v0.2.0.md
+++ b/docs/v0.2.0/driver-contract-v0.2.0.md
@@ -93,6 +93,15 @@ Destroy must be externally observable as follows:
 - any per-device simulator attachment is stopped or rejected before destruction completes
 - outstanding references held by userspace fail with the documented transport error for that surface
 
+Required destroy outcomes by surface:
+
+| Surface | Required outcome after destroy becomes visible |
+|---|---|
+| control plane | subsequent `device.get`, `device.set`, `device.reset`, `device.stats`, and `device.stats_reset` return `unknown-device` |
+| sysfs subtree | `/sys/kernel/virtrtlab/devices/<device>/` disappears; later reads or writes fail as absent paths |
+| simulator dataplane socket | existing connections are closed and later connection attempts fail because the device dataplane endpoint no longer exists |
+| AUT-facing endpoint | new opens or acquisitions fail because the device no longer exists; previously opened handles must not continue to report successful new I/O after destroy becomes visible |
+
 ## 5. Mandatory discovery surface
 
 Each device instance must expose the following fields through the daemon control plane.
@@ -131,8 +140,9 @@ Required minimum read-side attributes:
 |---|---|---|
 | `type` | ro | device type |
 | `bus` | ro | owning VirtRTLab bus or lab scope |
-| `state` | ro | current lifecycle or enablement state |
-| `stats/` | ro subtree plus reset entry | per-device counters |
+| `state` | ro | current device lifecycle state; one of `creating`, `up`, `resetting`, `destroying`, or `error` |
+| `stats/` | ro subtree | per-device counters |
+| `stats/reset` | wo compatibility entry | writing `1` resets the same counters as `device.stats_reset`; any other value is invalid |
 
 Additional read-only attributes are device-specific.
 
@@ -164,6 +174,19 @@ Each driver must validate:
 - out-of-range scalar values
 - malformed structured payloads
 - requests that conflict with the current device state
+
+Common persistent-attribute range rules:
+
+| Attribute | Type | Valid values | Notes |
+|---|---|---|---|
+| `enabled` | boolean | `true` or `false` | disables or enables the fault surface without renaming or removing the device |
+| `latency_ns` | integer | `0` to implementation maximum inclusive | unit is nanoseconds; negative values and integer overflow are invalid |
+| `jitter_ns` | integer | `0` to implementation maximum inclusive | unit is nanoseconds; negative values and integer overflow are invalid |
+| `drop_rate_ppm` | integer | `0` to `1000000` inclusive | probability per million transfer units |
+| `bitflip_rate_ppm` | integer | `0` to `1000000` inclusive | probability per million transfer units |
+
+If a driver imposes a lower implementation maximum for `latency_ns` or
+`jitter_ns`, values above that maximum must fail with `invalid-value`.
 
 ### 7.3 Reset
 
@@ -201,6 +224,19 @@ Each supported fault surface must specify:
 
 If a driver does not support one of the common fault attrs, it must reject the
 field explicitly rather than silently ignore it.
+
+Common device-state values exposed through sysfs and the control plane:
+
+| State | Meaning |
+|---|---|
+| `creating` | the device is being materialized and is not yet ready for normal operator use |
+| `up` | the device exists and is in its normal operator-usable state |
+| `resetting` | a reset operation is in progress |
+| `destroying` | a destroy operation is in progress |
+| `error` | the device hit an operational failure requiring operator attention |
+
+Drivers may expose transitional states only while the corresponding operation is
+in progress. The normal quiescent state of an existing usable device is `up`.
 
 ## 9. Driver capability declaration
 
@@ -257,7 +293,8 @@ Examples: `gpio`.
 Additional obligations:
 
 - define line addressing and valid line ranges
-- define behavior when the AUT currently owns a line as output
+- reject simulator-originated bank-state writes with `state-conflict` when any targeted line is currently owned by the AUT as output
+- apply GPIO dataplane writes atomically per octet: if any targeted line conflicts with current AUT output ownership, none of the written bits take effect
 - define edge-event or sampled-value semantics where applicable
 - define the simulator-facing bank-state dataplane semantics if a dataplane socket is exposed
 - if a dataplane socket is exposed in `v0.2.0`, the device must expose exactly
@@ -273,6 +310,7 @@ Each driver contract must map failures into stable daemon-visible categories.
 | unsupported attr name | `unknown-attribute` |
 | attempt to write read-only field | `read-only-attribute` |
 | invalid scalar or structured value | `invalid-value` or `invalid-payload` |
+| existing object but incompatible target relationship | `incompatible-target` |
 | state conflict | `state-conflict` |
 | kernel-side failure | `kernel-failure` |
 

--- a/docs/v0.2.0/driver-contract-v0.2.0.md
+++ b/docs/v0.2.0/driver-contract-v0.2.0.md
@@ -1,0 +1,302 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# VirtRTLab Driver Contract (v0.2.0 Draft)
+
+This document defines the observable contract that a kernel driver must satisfy
+to be managed by VirtRTLab in `v0.2.0`.
+
+It is the driver-side counterpart to
+[simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md): one document
+defines how userspace simulators plug into VirtRTLab, the other defines how
+kernel device models plug into the same control and lifecycle framework.
+
+## 1. Scope
+
+The driver contract covers:
+
+- driver registration into the VirtRTLab control plane
+- dynamic creation and destruction of device instances
+- identity, discovery, and lifecycle states
+- required observability surfaces
+- required control operations and error behavior
+
+The driver contract does not cover:
+
+- internal locking strategy inside a driver
+- the exact kernel API used to implement dynamic instantiation
+- protocol-specific simulator behavior
+
+## 2. Design goals
+
+Every VirtRTLab-compatible driver must satisfy these goals:
+
+- device instances are creatable and removable at runtime without reloading the module
+- the daemon can discover capabilities and validate control requests before they reach the device
+- read-side observability remains available through stable sysfs naming
+- write-side control is mediated by the daemon control socket in the normal installed profile
+- AUT-visible controller configuration remains under AUT control through normal Linux interfaces
+
+## 3. Required concepts
+
+### 3.1 Driver type identity
+
+Each compatible driver exposes one stable device type string.
+
+| Property | Rule |
+|---|---|
+| Character set | lowercase ASCII letters, digits, `-` |
+| Examples | `uart`, `gpio`, `can`, `spi` |
+| Stability | once published, a type name is stable across the `v0.2.x` line |
+
+### 3.2 Device instance identity
+
+Each runtime instance is named `<type><N>`.
+
+| Example | Meaning |
+|---|---|
+| `uart0` | first UART instance |
+| `gpio3` | fourth GPIO bank instance |
+
+Rules:
+
+- indices are zero-based per device type
+- names must remain unique within one daemon instance
+- removing one device does not rename surviving siblings
+
+## 4. Mandatory lifecycle operations
+
+Every compatible driver must support the following externally observable operations.
+
+| Operation | Required behavior |
+|---|---|
+| create | materialize one new device instance at runtime |
+| destroy | remove one existing device instance at runtime |
+| get | return identity, resolved host paths, and current attribute values |
+| set | update writable device attributes atomically per request |
+| reset | restore the documented reset baseline for that device |
+| stats | expose per-device counters |
+| stats_reset | reset per-device counters |
+
+### 4.1 Create
+
+Create must be externally observable as follows:
+
+- the device appears in `device.list`
+- all required read-side sysfs nodes become visible before success is reported
+- AUT-facing device nodes or paths, if any, are resolved before success is reported
+
+### 4.2 Destroy
+
+Destroy must be externally observable as follows:
+
+- the device disappears from `device.list`
+- any per-device simulator attachment is stopped or rejected before destruction completes
+- outstanding references held by userspace fail with the documented transport error for that surface
+
+## 5. Mandatory discovery surface
+
+Each device instance must expose the following fields through the daemon control plane.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `name` | string | device instance name, for example `uart0` |
+| `type` | string | device type, for example `uart` |
+| `state` | string | lifecycle state visible to userspace |
+| `paths` | object | resolved host-facing paths for AUT, simulator, and diagnostics |
+| `attrs` | object | current attribute values |
+| `stats` | object | current counter values |
+
+`paths` is device-specific. Examples:
+
+| Device type | Required path keys |
+|---|---|
+| `uart` | `aut_path`, `data_path`, `sysfs_path` |
+| `gpio` | `chip_path`, `data_path`, `sysfs_path` |
+
+## 6. Mandatory observability surface
+
+### 6.1 Sysfs
+
+Read-side sysfs observability remains mandatory.
+
+Each compatible driver must expose a stable per-device subtree under:
+
+```text
+/sys/kernel/virtrtlab/devices/<device>/
+```
+
+Required minimum read-side attributes:
+
+| Attribute | Access | Meaning |
+|---|---|---|
+| `type` | ro | device type |
+| `bus` | ro | owning VirtRTLab bus or lab scope |
+| `state` | ro | current lifecycle or enablement state |
+| `stats/` | ro subtree plus reset entry | per-device counters |
+
+Additional read-only attributes are device-specific.
+
+### 6.2 Writable sysfs
+
+Writable sysfs attrs are optional compatibility surfaces in `v0.2.0`.
+
+Rules:
+
+- the canonical control contract is the daemon control socket
+- if a driver still exposes writable sysfs attrs, their semantics must match the control-socket operations exactly
+- scripts and CI harnesses must not rely on writable sysfs attrs as the primary control path in `v0.2.0`
+
+## 7. Mandatory control semantics
+
+### 7.1 Atomicity
+
+For any multi-field update request such as `device.set`, the driver-visible result
+must be atomic from userspace:
+
+- either all fields are applied
+- or none are applied and the old values remain visible
+
+### 7.2 Validation
+
+Each driver must validate:
+
+- unknown field names
+- out-of-range scalar values
+- malformed structured payloads
+- requests that conflict with the current device state
+
+### 7.3 Reset
+
+Each driver must document a reset baseline.
+
+Minimum reset obligations:
+
+- clear runtime fault injection state unless that state is explicitly documented as persistent across reset
+- reset all documented stats counters to zero
+- leave device identity and index unchanged
+- return the device to an operator-usable state unless the type-specific spec says otherwise
+
+### 7.4 AUT configuration boundary
+
+The driver contract must preserve the AUT configuration boundary.
+
+Rules:
+
+- controller configuration that would exist on a real device remains under AUT control
+- the daemon control plane does not replace AUT-facing configuration interfaces such as `termios`, GPIO sysfs, or GPIO `ioctl`
+- the simulator-facing dataplane must not be specified as a controller-configuration interface
+
+## 8. Mandatory fault model hooks
+
+A VirtRTLab-compatible driver must declare its supported fault surfaces.
+
+Each supported fault surface must specify:
+
+| Field | Meaning |
+|---|---|
+| transfer unit | what one probability draw or delay applies to |
+| supported persistent attrs | such as `enabled`, `latency_ns`, `jitter_ns`, `drop_rate_ppm`, `bitflip_rate_ppm` |
+| supported one-shot injections | such as `line-write` or `rx-bytes` |
+| directionality | AUT-to-simulator, simulator-to-AUT, harness-to-AUT, or other |
+
+If a driver does not support one of the common fault attrs, it must reject the
+field explicitly rather than silently ignore it.
+
+## 9. Driver capability declaration
+
+The daemon must be able to discover driver capabilities.
+
+Normative capability fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `type` | string | device type |
+| `hotplug` | boolean | runtime create/destroy supported |
+| `max_devices` | integer or `null` | implementation maximum, if bounded |
+| `line_count` | integer or `null` | physical line count for line-oriented devices, else `null` |
+| `persistent_attrs` | array of strings | writable attr names accepted by `device.set` |
+| `injection_kinds` | array of strings | supported `fault.inject` kinds |
+| `path_keys` | array of strings | path keys returned by `device.get` |
+
+Illustrative capability object:
+
+```json
+{
+  "type": "gpio",
+  "hotplug": true,
+  "max_devices": 32,
+  "line_count": 8,
+  "persistent_attrs": [
+    "enabled",
+    "latency_ns",
+    "jitter_ns",
+    "drop_rate_ppm",
+    "bitflip_rate_ppm"
+  ],
+  "injection_kinds": ["line-write"],
+  "path_keys": ["chip_path", "data_path", "sysfs_path"]
+}
+```
+
+## 10. Driver-specific obligations
+
+### 10.1 Stream-oriented drivers
+
+Examples: `uart`, future `can`.
+
+Additional obligations:
+
+- define the AUT-facing endpoint path
+- define the simulator-facing dataplane path if one exists
+- define behavior on disconnect, reset, and destroy while endpoints are open
+
+### 10.2 Line-oriented drivers
+
+Examples: `gpio`.
+
+Additional obligations:
+
+- define line addressing and valid line ranges
+- define behavior when the AUT currently owns a line as output
+- define edge-event or sampled-value semantics where applicable
+- define the simulator-facing bank-state dataplane semantics if a dataplane socket is exposed
+- if a dataplane socket is exposed in `v0.2.0`, the device must expose exactly
+  8 physical lines and advertise `line_count = 8`
+
+## 11. Error behavior
+
+Each driver contract must map failures into stable daemon-visible categories.
+
+| Condition | Required outcome |
+|---|---|
+| unknown device name | `unknown-device` |
+| unsupported attr name | `unknown-attribute` |
+| attempt to write read-only field | `read-only-attribute` |
+| invalid scalar or structured value | `invalid-value` or `invalid-payload` |
+| state conflict | `state-conflict` |
+| kernel-side failure | `kernel-failure` |
+
+## 12. Rationale
+
+**Why require hotplug for VirtRTLab-managed drivers?**  
+The main `v0.2.0` goal is to let CI and operators reconfigure a lab without
+reloading kernel modules or taking a privileged module-management path for every
+test scenario.
+
+**Why keep sysfs mandatory for observability?**  
+It preserves shell-friendly diagnostics and keeps driver state inspectable even
+when the daemon or CLI is not the active debugging tool.
+
+**Why make writable sysfs secondary?**  
+One canonical write-side control plane avoids semantic drift and permission
+surprises between CLI, daemon, and direct shell access.
+
+## 13. Decisions
+
+- support for persistent fault attributes is sufficient for the base driver
+  contract in `v0.2.0`; one-shot fault injection kinds are optional driver
+  capabilities, not a compatibility gate
+- all VirtRTLab-compatible drivers in `v0.2.0` attach to one shared
+  kernel-visible VirtRTLab aggregation object for discovery and diagnostics;
+  the observable hierarchy remains common even when internal implementation
+  details differ by driver type

--- a/docs/v0.2.0/privilege-model-v0.2.0.md
+++ b/docs/v0.2.0/privilege-model-v0.2.0.md
@@ -37,7 +37,7 @@ Canonical service account: `virtrtlab`
 |---|---|---|---|---|
 | Control socket | resolved daemon control-socket path; default installed path `/run/virtrtlab/control.sock` | `virtrtlab:virtrtlab` | `0660` | CLI, CI harnesses, diagnostics |
 | Data sockets | resolved per-device dataplane paths; default installed pattern `/run/virtrtlab/devices/*.sock` | `virtrtlab:virtrtlab` | `0660` | simulator processes |
-| Runtime directory | resolved daemon runtime root; default installed path `/run/virtrtlab/` | `virtrtlab:virtrtlab` | `0750` | daemon and group members |
+| Runtime directory | resolved daemon runtime root; default installed path `/run/virtrtlab` | `virtrtlab:virtrtlab` | `0750` | daemon and group members |
 | AUT-facing device nodes | VirtRTLab-owned `/dev/*` endpoints | group `virtrtlab` | `0660` | AUT binaries and harnesses |
 | Sysfs read-only attrs | `/sys/kernel/virtrtlab/**` | readable without group write ownership | `0444` | diagnostics |
 
@@ -143,7 +143,7 @@ behavior and hard-to-debug CI failures.
 ## 11. Decisions
 
 - the daemon does not stop or restart itself as part of routine `v0.2.0`
-	operation; hotplug-capable device lifecycle removes the need for daemon
-	self-restart in the normal model
+  operation; hotplug-capable device lifecycle removes the need for daemon
+  self-restart in the normal model
 - in the installed profile, managed simulator lifecycle is daemon-owned for
-	uniformity; the CLI does not become an alternative execution authority
+  uniformity; the CLI does not become an alternative execution authority

--- a/docs/v0.2.0/privilege-model-v0.2.0.md
+++ b/docs/v0.2.0/privilege-model-v0.2.0.md
@@ -35,9 +35,9 @@ Canonical service account: `virtrtlab`
 
 | Surface | Path pattern | Owner/group contract | Mode contract | Primary consumer |
 |---|---|---|---|---|
-| Control socket | `/run/virtrtlab/control.sock` | `virtrtlab:virtrtlab` | `0660` | CLI, CI harnesses, diagnostics |
-| Data sockets | `/run/virtrtlab/devices/*.sock` | `virtrtlab:virtrtlab` | `0660` | simulator processes |
-| Runtime directory | `/run/virtrtlab/` | `virtrtlab:virtrtlab` | `0750` | daemon and group members |
+| Control socket | resolved daemon control-socket path; default installed path `/run/virtrtlab/control.sock` | `virtrtlab:virtrtlab` | `0660` | CLI, CI harnesses, diagnostics |
+| Data sockets | resolved per-device dataplane paths; default installed pattern `/run/virtrtlab/devices/*.sock` | `virtrtlab:virtrtlab` | `0660` | simulator processes |
+| Runtime directory | resolved daemon runtime root; default installed path `/run/virtrtlab/` | `virtrtlab:virtrtlab` | `0750` | daemon and group members |
 | AUT-facing device nodes | VirtRTLab-owned `/dev/*` endpoints | group `virtrtlab` | `0660` | AUT binaries and harnesses |
 | Sysfs read-only attrs | `/sys/kernel/virtrtlab/**` | readable without group write ownership | `0444` | diagnostics |
 

--- a/docs/v0.2.0/privilege-model-v0.2.0.md
+++ b/docs/v0.2.0/privilege-model-v0.2.0.md
@@ -1,0 +1,149 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# VirtRTLab Privilege Model (v0.2.0 Draft)
+
+This document defines the observable privilege model for the `v0.2.0` control
+plane.
+
+It supersedes the `v0.1` assumption that routine control is performed directly
+through writable sysfs attrs or repeated privileged module lifecycle commands.
+
+## 1. Overview
+
+VirtRTLab `v0.2.0` follows this rule:
+
+**routine lab control is non-root and daemon-mediated.**
+
+The daemon holds the narrow privileged path required to materialize and destroy
+kernel-backed device instances. Operators and CI jobs interact with the daemon
+through the control socket.
+
+Canonical group name: `virtrtlab`
+
+Canonical service account: `virtrtlab`
+
+## 2. Actors
+
+| Actor | Typical identity | Allowed operations | Not allowed |
+|---|---|---|---|
+| Installer | root | install files, create accounts, enable service integration | normal day-to-day control is not the install path |
+| Lab user | member of `virtrtlab` | connect to the control socket, run `virtrtlabctl`, access device nodes and data sockets, inject faults | arbitrary root shell operations |
+| Daemon service | user `virtrtlab`, group `virtrtlab`, with a narrow privileged execution context configured by the service manager | create and destroy VirtRTLab devices, supervise simulators, manage runtime files | unrestricted root session |
+| CI runner | user or service account in `virtrtlab` | run repeated `up`, `down`, simulator lifecycle, and fault injection without interactive privilege escalation | direct unrestricted kernel module management |
+
+## 3. Access surfaces
+
+| Surface | Path pattern | Owner/group contract | Mode contract | Primary consumer |
+|---|---|---|---|---|
+| Control socket | `/run/virtrtlab/control.sock` | `virtrtlab:virtrtlab` | `0660` | CLI, CI harnesses, diagnostics |
+| Data sockets | `/run/virtrtlab/devices/*.sock` | `virtrtlab:virtrtlab` | `0660` | simulator processes |
+| Runtime directory | `/run/virtrtlab/` | `virtrtlab:virtrtlab` | `0750` | daemon and group members |
+| AUT-facing device nodes | VirtRTLab-owned `/dev/*` endpoints | group `virtrtlab` | `0660` | AUT binaries and harnesses |
+| Sysfs read-only attrs | `/sys/kernel/virtrtlab/**` | readable without group write ownership | `0444` | diagnostics |
+
+## 4. Control path policy
+
+### 4.1 Canonical write-side control
+
+The following operations must be performed through the daemon control socket in
+the normal installed profile:
+
+- lab up/down/reconfigure
+- device create/destroy
+- device attribute writes
+- stats reset
+- one-shot fault injection
+- simulator attach/start/stop/detach
+
+### 4.2 Sysfs write policy
+
+Writable sysfs attrs may remain available for debugging or compatibility, but
+they are not the normative privilege path in `v0.2.0`.
+
+Rules:
+
+- unprivileged automation must not depend on direct sysfs writes
+- if writable sysfs attrs exist, their access policy may be stricter than the control socket policy
+- the daemon remains responsible for presenting stable operator-facing errors and validation
+
+## 5. Daemon privilege contract
+
+| Property | Required behavior | Error behavior |
+|---|---|---|
+| Identity | runs as user `virtrtlab`, group `virtrtlab` | service start fails if the account cannot be resolved |
+| Privileged path | obtains only the capabilities or service-manager privileges needed to create and destroy VirtRTLab device instances | service start fails if the service manager cannot apply the configured policy |
+| Runtime ownership | creates sockets and runtime files with group-visible permissions | clients receive normal `EACCES` or connect failures if the daemon is absent or misconfigured |
+| Root policy | must not require an unrestricted root shell for routine steady-state operation | configuration is invalid if the installed profile depends on full-root daemon operation |
+
+The exact service-manager mechanism is distribution-specific. The normative
+contract is the outcome: a long-running daemon that can perform the narrow
+device-lifecycle operations required by VirtRTLab without exposing a general
+root control surface to lab users.
+
+## 6. CLI privilege contract
+
+After installation and group-membership setup, the following commands must
+succeed for a `virtrtlab` group member without interactive `sudo`:
+
+| Command family | Expected privilege path |
+|---|---|
+| `up`, `down`, `status` | control socket |
+| `list`, `get`, `set`, `reset`, `stats`, `inject` | control socket |
+| `sim *` | control socket for lifecycle, data sockets for simulator processes |
+
+If the daemon is unavailable, the CLI must fail with a normal daemon-unavailable
+error. It must not silently fall back to direct privileged module commands in
+the installed profile.
+
+## 7. Simulator process privilege contract
+
+Managed simulator processes are started by the daemon or by a daemon-authorized
+supervisor path.
+
+Required outcomes:
+
+- the simulator has access to the target data socket without additional privilege escalation
+- the simulator does not require root by default
+- simulator-specific extra privileges, if any, are declared by that simulator and are outside the base VirtRTLab contract
+
+In the installed profile, the daemon is the authoritative owner of managed
+simulator lifecycle. `virtrtlabctl` is the operator-facing client of that
+daemon-managed lifecycle.
+
+## 8. Root-only operations
+
+The following remain root-only by design:
+
+| Operation | Reason |
+|---|---|
+| package installation and uninstall | machine-wide state changes |
+| initial service enablement and service-manager policy changes | administrative action |
+| out-of-band kernel module installation or update | machine-wide kernel integration |
+
+## 9. Error behavior
+
+| Condition | Required behavior |
+|---|---|
+| user not in `virtrtlab` | connect or open fails with standard permission error |
+| daemon absent | control commands fail with daemon/socket error |
+| daemon privilege path misconfigured | service start fails; CLI reports daemon unavailable or operational failure |
+| direct writable sysfs unavailable | not treated as a control-plane regression if the control socket contract is satisfied |
+
+## 10. Rationale
+
+**Why move routine control away from direct sysfs writes?**  
+It gives VirtRTLab one place to validate topology changes, serialize conflicting
+operations, and express structured errors to CI and operator tooling.
+
+**Why avoid fallback to `sudo` in the installed profile?**  
+The whole point of the `v0.2.0` model is to make test sequencing predictable and
+non-interactive. Silent privilege escalation would reintroduce environment-specific
+behavior and hard-to-debug CI failures.
+
+## 11. Decisions
+
+- the daemon does not stop or restart itself as part of routine `v0.2.0`
+	operation; hotplug-capable device lifecycle removes the need for daemon
+	self-restart in the normal model
+- in the installed profile, managed simulator lifecycle is daemon-owned for
+	uniformity; the CLI does not become an alternative execution authority

--- a/docs/v0.2.0/simulator-contract-v0.2.0.md
+++ b/docs/v0.2.0/simulator-contract-v0.2.0.md
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 
-# VirtRTLab Simulator Contract (v0.2 Draft)
+# VirtRTLab Simulator Contract (v0.2.0 Draft)
 
 This document is the source of truth for the simulator catalog and lifecycle contract targeted at `v0.2.0`.
 
@@ -432,6 +432,11 @@ Bus reset semantics:
 
 This preserves the existing daemon model and avoids conflating bus reset with process supervision.
 
+Path-discovery rule:
+
+- simulator processes must use the resolved runtime paths passed by environment variables such as `VIRTRTLAB_SIM_SOCKET`, `VIRTRTLAB_SIM_CONFIG`, and `VIRTRTLAB_SIM_LOG_DIR`
+- examples under `/run/virtrtlab/...` are the default installed layout, not the only valid deployed layout
+
 ### 4.5 Profile-driven startup failure semantics
 
 `virtrtlabctl up --config <file>` may materialize multiple attachments from one lab profile.
@@ -567,6 +572,10 @@ Managed simulator state lives under:
 /run/virtrtlab/simulators/
 ```
 
+This path is the default installed simulator runtime root. The resolved runtime
+root comes from daemon configuration and remains the value surfaced through the
+environment and control-plane-visible paths.
+
 The directory layout is per attached device.
 
 Canonical `v0.2.0` layout:
@@ -608,6 +617,7 @@ Rules:
 - `logs/` is created lazily on first start of the attachment
 - the daemon owns creation, mutation, and cleanup of this runtime state
 - `virtrtlabctl down` requests daemon-side cleanup of runtime-only state for active processes; `v0.2.0` initial expectation is full cleanup of process runtime under `/run`
+- these files are a normative simulator-runtime observability surface only; they do not replace the control socket as the topology-control API
 
 ### 5.6.1 Per-device `state.json` format
 
@@ -847,6 +857,7 @@ The initial persistence contract is intentionally simple:
 - attachment definitions created by `sim attach` are runtime-local, not reboot-persistent
 - `state.json`, `attachment.toml`, `config.toml`, `pid`, and `logs/` are all disposable runtime artifacts
 - after reboot or any loss of `/run/virtrtlab/simulators/`, no attachment is considered to exist anymore unless it is recreated by `sim attach` or `up --config`
+- no daemon or CLI client may treat these runtime files as a durable substitute for control-plane topology state
 
 Observable semantics by event:
 
@@ -1267,7 +1278,7 @@ Recommended mapping for simulator commands:
 | 1 | Operational error (spawn failure, process stop timeout, catalog parse error, filesystem error) |
 | 2 | Bad arguments, ambiguous simulator version selection, invalid config syntax, or parameter type validation error |
 | 3 | State conflict (already running, already attached, already starting) |
-| 4 | Not found or incompatible target (unknown simulator, unknown device, unsupported device kind, no attachment) |
+| 4 | Not found or incompatible target (unknown simulator, unknown device, incompatible target, no attachment) |
 
 Stable JSON error envelope:
 

--- a/docs/v0.2.0/simulator-contract-v0.2.0.md
+++ b/docs/v0.2.0/simulator-contract-v0.2.0.md
@@ -4,9 +4,15 @@
 
 This document is the source of truth for the simulator catalog and lifecycle contract targeted at `v0.2.0`.
 
-It defines how `virtrtlabctl` discovers simulators, how a simulator is attached to a VirtRTLab device, and which runtime context is passed to the simulator process.
+It defines how the VirtRTLab control plane discovers simulators, how a
+simulator is attached to a VirtRTLab device, and which runtime context is
+passed to the simulator process.
 
-This contract belongs to VirtRTLab itself. Protocol-specific simulators such as GPS, sensor, switch-console, or register-oriented component peers may live in separate repositories, but they must conform to the rules defined here if they want to be managed by `virtrtlabctl`.
+In `v0.2.0`, the daemon is the authoritative owner of simulator attachment and
+lifecycle state. `virtrtlabctl` remains the normal human-facing client of that
+daemon control plane.
+
+This contract belongs to VirtRTLab itself. Protocol-specific simulators such as GPS, sensor, switch-console, or register-oriented component peers may live in separate repositories, but they must conform to the rules defined here if they want to be managed by VirtRTLab.
 
 ---
 
@@ -19,7 +25,7 @@ The contract covers:
 - simulator catalog discovery
 - user-extensible simulator definitions
 - device-to-simulator attachment
-- runtime context passed by `virtrtlabctl`
+- runtime context passed by the daemon-managed simulator lifecycle
 - lifecycle expectations for start, stop, failure, and teardown
 
 The contract does not cover:
@@ -80,7 +86,7 @@ loopback.toml
 
 ### 3.3 Discovery paths and precedence
 
-`virtrtlabctl` searches simulator definitions in the following precedence order.
+The VirtRTLab control plane searches simulator definitions in the following precedence order.
 Later entries override earlier ones when the simulator name is identical.
 
 | Precedence | Path | Purpose |
@@ -109,7 +115,7 @@ Required top-level keys:
 | `name` | string | Stable simulator name used by CLI and profiles. |
 | `version` | string | Simulator version identifier. Required for validation traceability. |
 | `summary` | string | One-line human-readable description. |
-| `exec` | array of strings | Command vector executed by `virtrtlabctl` (`execve` style). |
+| `exec` | array of strings | Command vector executed by the daemon-managed simulator launcher (`execve` style). |
 | `supports` | array of strings | Supported VirtRTLab device kinds such as `uart`, later `spi` or `i2c`. |
 
 Optional top-level keys:
@@ -216,7 +222,8 @@ In `v0.2.0`, the attachment model is intentionally simple:
 - one managed simulator attachment targets exactly one VirtRTLab device
 - no fan-out, tap, or observer graph is defined in `v0.2.0`
 
-This matches the existing single-active-connection model on `/run/virtrtlab/<device>.sock`.
+This matches the single-active-connection dataplane model on
+`/run/virtrtlab/devices/<device>.sock`.
 
 ### 4.2 Attachment states
 
@@ -226,9 +233,9 @@ An attachment has the following conceptual states:
 |---|---|
 | `detached` | no simulator is associated with the device |
 | `attached` | simulator is selected but not running |
-| `starting` | `virtrtlabctl` is launching the simulator |
+| `starting` | the daemon is launching the simulator |
 | `running` | simulator process exists and has not exited; in `v0.2.0` this is a liveness state, not a readiness guarantee |
-| `stopping` | `virtrtlabctl` has requested termination and is waiting for process exit |
+| `stopping` | the daemon has requested termination and is waiting for process exit |
 | `failed` | launch failed or the simulator exited unexpectedly |
 | `stopped` | simulator was previously running and has been stopped cleanly |
 
@@ -269,7 +276,7 @@ Validation rules:
 - `device` must exist in the resolved device set
 - `simulator` must exist in the resolved catalog
 - if `version` is present, the `(simulator, version)` pair must exist in the resolved catalog
-- if `version` is absent and multiple visible catalog entries share the same simulator name, validation fails with an ambiguity error
+- if `version` is absent and multiple visible catalog entries share the same simulator name, validation fails with `ambiguous-simulator-version`
 - the simulator must support the target device kind
 - unknown `config` keys are rejected
 - missing required parameters are rejected
@@ -390,11 +397,11 @@ delay_ms = 0
 
 Lifecycle expectations in `v0.2.0`:
 
-- `virtrtlabctl up --config` may create and auto-start declared attachments
+- `virtrtlabctl up --config` may request that the daemon create and auto-start declared attachments
 - only attachments with `auto_start = true` are started automatically by default
-- `virtrtlabctl down` stops managed simulators before tearing down kernel modules
+- `virtrtlabctl down` requests that the daemon stop managed simulators before tearing down the active lab topology
 - if a simulator exits unexpectedly, the attachment state becomes `failed`
-- `restart_policy = "never"` means `virtrtlabctl` records failure and does not restart automatically
+- `restart_policy = "never"` means the daemon records failure and does not restart automatically
 - `restart_policy = "on-failure"` means a later revision may restart automatically; the contract reserves the value now but does not require immediate implementation sophistication
 
 `restart_policy` semantics in `v0.2.0`:
@@ -469,7 +476,7 @@ The command line is kept stable and explicit:
 
 - `exec` and `args` come from the catalog entry
 - `virtrtlabctl` does **not** invent hidden positional arguments
-- the resolved attachment configuration is written to a file and exposed through an environment variable
+- the resolved attachment configuration is written by the daemon to a file and exposed through an environment variable
 
 This keeps third-party simulators shell-agnostic and avoids a fragile placeholder-expansion mini-language in `v0.2.0`.
 
@@ -481,10 +488,10 @@ This keeps third-party simulators shell-agnostic and avoids a fragile placeholde
 | `VIRTRTLAB_SIM_INSTANCE_ID` | string | Runtime-unique attachment instance identifier. |
 | `VIRTRTLAB_SIM_DEVICE` | string | Target device name, e.g. `uart0`. |
 | `VIRTRTLAB_SIM_DEVICE_TYPE` | string | Device kind, e.g. `uart`. |
-| `VIRTRTLAB_SIM_SOCKET` | absolute path | Runtime socket path to connect to, e.g. `/run/virtrtlab/uart0.sock`. |
+| `VIRTRTLAB_SIM_SOCKET` | absolute path | Runtime dataplane socket path to connect to, e.g. `/run/virtrtlab/devices/uart0.sock`. |
 | `VIRTRTLAB_SIM_RUN_DIR` | absolute path | VirtRTLab runtime directory, e.g. `/run/virtrtlab`. |
 | `VIRTRTLAB_SIM_CONTROL_DIR` | absolute path | Sysfs control root for the target device when available, e.g. `/sys/kernel/virtrtlab/devices/uart0`. |
-| `VIRTRTLAB_SIM_CONFIG` | absolute path | Resolved attachment configuration file written by `virtrtlabctl`. |
+| `VIRTRTLAB_SIM_CONFIG` | absolute path | Resolved attachment configuration file written by the daemon. |
 | `VIRTRTLAB_SIM_LOG_DIR` | absolute path | Directory reserved for simulator log files (e.g. `stdout.log`, `stderr.log`). |
 
 Optional variables reserved for later use:
@@ -506,12 +513,12 @@ Rules:
 
 - `exec` is required and must not be empty
 - `args` is optional and may be empty
-- `virtrtlabctl` does not append implicit `--socket`, `--device`, or positional arguments in `v0.2.0`
+- the daemon-managed launcher does not append implicit `--socket`, `--device`, or positional arguments in `v0.2.0`
 - simulator authors must read runtime context from environment variables and the config file referenced by `VIRTRTLAB_SIM_CONFIG`
 
 ### 5.4 Resolved configuration file
 
-Before launching a simulator, `virtrtlabctl` writes the fully resolved attachment configuration to a TOML file.
+Before launching a simulator, the daemon writes the fully resolved attachment configuration to a TOML file.
 
 The file includes:
 
@@ -546,7 +553,7 @@ Managed simulators are ordinary userspace processes.
 
 In `v0.2.0`, the intended execution model is:
 
-- the simulator runs as the invoking user when that user already has access to `/run/virtrtlab/*.sock`
+- the simulator runs under the daemon-managed service context in the normal installed profile
 - the simulator must not require root by default
 - access to the runtime socket is granted by the existing `virtrtlab` group model
 
@@ -599,7 +606,8 @@ Rules:
 - `pid` exists only while a simulator process is believed alive
 - `state.json` remains after process exit so failures are inspectable
 - `logs/` is created lazily on first start of the attachment
-- `virtrtlabctl down` removes runtime-only state for active processes but may preserve attachment state if the command is later specified to support persistent lab attachments; `v0.2.0` initial expectation is full cleanup of process runtime under `/run`
+- the daemon owns creation, mutation, and cleanup of this runtime state
+- `virtrtlabctl down` requests daemon-side cleanup of runtime-only state for active processes; `v0.2.0` initial expectation is full cleanup of process runtime under `/run`
 
 ### 5.6.1 Per-device `state.json` format
 
@@ -747,10 +755,10 @@ Disallowed transitions and CLI outcomes:
 |---|---|---|
 | `running` | `sim start` | state conflict error |
 | `starting` | `sim start` | state conflict error |
-| `attached` | `sim stop` | operational error because no process exists |
-| `failed` | `sim stop` | operational error because no live process exists |
-| `detached` | `sim start` | not-found error because no attachment exists |
-| `detached` | `sim detach` | not-found error because no attachment exists |
+| `attached` | `sim stop` | state conflict error because no process is running |
+| `failed` | `sim stop` | state conflict error because no process is running |
+| `detached` | `sim start` | `not-attached` control-plane error, mapped to CLI exit code `4` |
+| `detached` | `sim detach` | `not-attached` control-plane error, mapped to CLI exit code `4` |
 
 Crash semantics:
 
@@ -815,7 +823,7 @@ Observable outcomes:
 | `sim attach uart0 ...` racing with `sim detach uart0` | serialized; final state matches command completion order |
 | `sim status uart0` during `sim start uart0` | may report `attached`, `starting`, or `running`, but must return a coherent single state object |
 | `sim status` during updates on multiple devices | aggregate output may reflect some devices before and others after independent operations, but each per-device object must be coherent |
-| `down` racing with any `sim * <device>` mutation | `down` wins once it acquires the relevant lock scope; later commands fail with operational or not-found errors depending on the resulting lab state |
+| `down` racing with any `sim * <device>` mutation | `down` wins once it acquires the relevant lock scope; later commands fail with operational, `not-attached`, or `unknown-device` outcomes depending on the resulting lab state |
 
 The contract does not require fairness beyond eventual completion.
 It does require bounded waiting or explicit failure rather than indefinite blocking.
@@ -855,9 +863,9 @@ Observable semantics by event:
 Rules for commands after runtime loss:
 
 - `sim status` with no existing runtime directory returns an empty attachment set, not an operational error
-- `sim status <device>` returns not found when no per-device runtime state exists
-- `sim start <device>` returns not found when the attachment runtime directory is absent, even if a simulator process somehow still exists outside management
-- `sim detach <device>` returns not found when no managed attachment runtime state exists
+- `sim status <device>` returns a no-attachment condition for an existing device and a not-found condition only when the device itself is absent
+- `sim start <device>` returns a no-attachment condition when the attachment runtime directory is absent, even if a simulator process somehow still exists outside management
+- `sim detach <device>` returns a no-attachment condition when no managed attachment runtime state exists
 
 Relationship with profiles:
 
@@ -887,7 +895,7 @@ It is both:
 
 In `v0.2.0`, `loopback` supports only `uart` attachments.
 
-It connects to the runtime socket specified by `VIRTRTLAB_SIM_SOCKET` and echoes received bytes back to the same link.
+It connects to the runtime dataplane socket specified by `VIRTRTLAB_SIM_SOCKET` and echoes received bytes back to the same link.
 
 ### 6.2 Required behaviour
 
@@ -957,7 +965,7 @@ Its role is to make simulator process behaviour easy to control from tests.
 
 In `v0.2.0`, `test-stub` may support `uart` attachments only.
 
-It should still connect to `VIRTRTLAB_SIM_SOCKET` when operating in steady-state `run` mode so that attachment startup exercises the same socket-path contract as ordinary simulators.
+It should still connect to `VIRTRTLAB_SIM_SOCKET` when operating in steady-state `run` mode so that attachment startup exercises the same dataplane-socket path contract as ordinary simulators.
 
 #### Required behaviour
 
@@ -1112,8 +1120,8 @@ The output includes at least:
 
 Machine-readable contract:
 
-- `virtrtlabctl --json sim inspect <name>` returns one JSON object
-- when multiple visible versions share the same simulator name, `--version VERSION` is required
+- `virtrtlabctl --json sim inspect <name>` returns exactly the daemon `result` payload for `sim.inspect`
+- when multiple visible versions share the same simulator name, `--version VERSION` is required and the daemon error is `ambiguous-simulator-version`
 - field names must match catalog semantics directly and remain stable across `v0.2.x`
 - unknown optional catalog fields may be added later but existing fields must not change type
 
@@ -1143,9 +1151,11 @@ Behaviour:
 
 - validates that the device exists
 - validates that the selected simulator name exists, and if `--version` is provided validates the exact `(name, version)` pair
-- fails with an ambiguity error when multiple visible versions share the same simulator name and `--version` is omitted
+- fails with `ambiguous-simulator-version` when multiple visible versions share the same simulator name and `--version` is omitted
 - validates that the resolved simulator supports the device kind
 - validates all provided config keys against declared parameters
+- replaces an existing attachment only when its current state is `attached`, `stopped`, or `failed`
+- attempting replacement while the current attachment is `starting`, `running`, or `stopping` fails with a state conflict
 - writes the resolved attachment state into the VirtRTLab runtime state directory
 - does **not** start the simulator process implicitly; use `sim start` or profile-driven startup
 
@@ -1157,7 +1167,7 @@ Behaviour:
 
 - if a simulator is currently running for the device, `sim detach` stops it first
 - attachment state and generated runtime config files are removed afterwards
-- detaching an already detached device returns a not-found style error
+- detaching an already detached device returns the control-plane error `not-attached`, which the CLI maps to exit code `4`
 
 ### 7.6 `sim start`
 
@@ -1166,6 +1176,7 @@ Starts the simulator attached to one device.
 Behaviour:
 
 - requires an existing attachment
+- returns the control-plane error `not-attached` when the device exists but has no attachment
 - fails if the attachment is already in `starting` or `running`
 - launches the simulator using the catalog `exec` and `args`
 - provides runtime context exclusively through the environment variables and config file defined in this document
@@ -1182,7 +1193,9 @@ Behaviour:
 - if the attachment is `running`, sends a graceful termination signal first
 - if the process does not exit within a bounded timeout, force-kills it
 - leaves the attachment definition in place and moves the state to `stopped`
-- stopping an attachment that is not running is a no-op success only when the state is already `stopped`; otherwise it is an error for a missing attachment
+- stopping an attachment that is already `stopped` is a no-op success
+- stopping an attachment in `attached` or `failed` returns a state conflict
+- stopping a device with no attachment returns the control-plane error `not-attached`, which the CLI maps to exit code `4`
 
 ### 7.8 `sim status`
 
@@ -1195,6 +1208,7 @@ Without argument:
 With `<device>`:
 
 - prints detailed status for the specified device only
+- if the device exists but has no attachment, the control-plane error is `not-attached`, which the CLI maps to exit code `4`
 
 Status payload includes at least:
 
@@ -1209,8 +1223,8 @@ Status payload includes at least:
 
 Machine-readable contract:
 
-- `virtrtlabctl --json sim status` returns the aggregate state file shape defined in section `5.6.2`
-- `virtrtlabctl --json sim status <device>` returns the per-device state file shape defined in section `5.6.1`
+- `virtrtlabctl --json sim status` returns exactly the daemon `result` payload for aggregate `sim.status`; that payload matches the aggregate state-file shape defined in section `5.6.2`
+- `virtrtlabctl --json sim status <device>` returns exactly the daemon `result` payload for per-device `sim.status`; that payload matches the per-device state-file shape defined in section `5.6.1`
 - human-readable output may evolve cosmetically, but the JSON schema is part of the compatibility contract
 
 Human-readable contract:
@@ -1251,7 +1265,7 @@ Recommended mapping for simulator commands:
 |---|---|
 | 0 | Success |
 | 1 | Operational error (spawn failure, process stop timeout, catalog parse error, filesystem error) |
-| 2 | Bad arguments, invalid config syntax, or parameter type validation error |
+| 2 | Bad arguments, ambiguous simulator version selection, invalid config syntax, or parameter type validation error |
 | 3 | State conflict (already running, already attached, already starting) |
 | 4 | Not found or incompatible target (unknown simulator, unknown device, unsupported device kind, no attachment) |
 
@@ -1266,6 +1280,7 @@ Rules:
 - the `error` string is for operators and logs
 - the numeric `code` is the scripting contract
 - the same numeric meaning must be preserved in human and JSON modes
+- control-plane string errors such as `ambiguous-simulator-version` and `not-attached` are preserved only inside daemon responses; the CLI contract remains numeric at this layer
 
 Human-readable error wording guidance:
 
@@ -1287,12 +1302,13 @@ They are written as observable behaviours, not implementation tests.
 | crash transition | killing the simulator unexpectedly yields `failed`, null `pid`, populated `last_error` or non-zero `last_exit_code` |
 | `on-failure` without supervisor | a simulator with `restart_policy = on-failure` still remains `failed` after crash until an explicit command acts |
 | restart after failure | `failed -> starting -> running` is observable and clears `last_error` on success |
-| detach cleanup | `sim detach` removes the per-device runtime directory and later `sim status <device>` returns not found |
+| detach cleanup | `sim detach` removes the per-device runtime directory and later `sim status <device>` returns `not-attached` when the device still exists |
 | aggregate status regeneration | deleting aggregate `state.json` and running `sim status` regenerates a coherent aggregate view |
 | lost runtime dir | removing `/run/virtrtlab/simulators/` makes `sim status` return an empty set |
 | invalid `--set` syntax | malformed `--set` returns exit code `2` |
 | invalid `--set` type | parameter type mismatch or overflow returns exit code `2` |
 | unknown top-level parameter | `sim attach --set unknown=...` returns exit code `4` or `2` only if the CLI cannot even parse the expression; preferred result is `4` for unknown target parameter |
+| ambiguous simulator version | `sim inspect` or `sim attach` without `--version` on a multiply-defined simulator returns exit code `2` |
 | concurrent `sim start` | one command succeeds, the other reports a coherent state conflict or already-running result |
 | concurrent `sim stop` and `sim start` | no torn state file is observed; final state matches serialized completion order |
 | profile partial auto-start failure | `up --config` returns non-zero, successful earlier attachments remain observable, failed one is in `failed`, later ones remain `attached` |
@@ -1325,6 +1341,6 @@ Environment variables are good for stable runtime context such as device names a
 
 ---
 
-## 9. Open questions
+## 9. Decision
 
 No open questions remain in this first draft of the simulator contract.

--- a/docs/v0.2.0/simulator-contract-v0.2.0.md
+++ b/docs/v0.2.0/simulator-contract-v0.2.0.md
@@ -430,6 +430,14 @@ Bus reset semantics:
 - `vrtlbus0 state=reset` does **not** imply that `virtrtlabctl` must kill the simulator process
 - managed simulators must tolerate daemon disconnect and later re-connection when the runtime socket becomes usable again
 
+Minimum reconnect contract after dataplane loss caused by reset:
+
+- a compliant simulator must treat loss of the current dataplane connection as a transient condition when the attachment state is still managed and the process is not being stopped
+- after observing EOF, connection reset, or initial connect failure during a reset window, the simulator should retry `connect()` to `VIRTRTLAB_SIM_SOCKET` with bounded backoff instead of exiting immediately
+- the retry backoff should be short and bounded; the recommended initial range for `v0.2.0` interoperability is 50 ms to 500 ms between attempts
+- no dedicated readiness event is required in `v0.2.0`; simulator authors should treat successful reconnect as the readiness signal for resumed dataplane traffic
+- operator tooling should not infer reconnect success from process liveness alone; it should use `sim status`, device-level reads, or an explicit end-to-end probe when reconnect timing matters
+
 This preserves the existing daemon model and avoids conflating bus reset with process supervision.
 
 Path-discovery rule:

--- a/docs/v0.2.0/socket-api-v0.2.0.md
+++ b/docs/v0.2.0/socket-api-v0.2.0.md
@@ -113,6 +113,12 @@ control through the normal Linux GPIO userspace interfaces.
 | bus or device reset invalidates the current data path | daemon closes and recreates the affected internal relay resources; the simulator connection is dropped |
 | device destroy | existing sessions are closed, new connections fail because the endpoint no longer exists, and the data socket path disappears for that device |
 
+Reconnect expectations after reset:
+
+- after a reset-driven disconnect, the daemon returns to accepting a new dataplane connection for that device once the internal relay resources are usable again
+- `v0.2.0` does not define a separate readiness notification on the dataplane socket itself
+- simulator processes are expected to retry connection attempts according to the simulator contract rather than waiting for an out-of-band reconnect signal
+
 Type-specific notes:
 
 - for UART, disconnect handling may flush stale AUT-to-simulator bytes before returning to waiting state

--- a/docs/v0.2.0/socket-api-v0.2.0.md
+++ b/docs/v0.2.0/socket-api-v0.2.0.md
@@ -1,0 +1,151 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# VirtRTLab Device Data Socket API (v0.2.0 Draft)
+
+This document defines the `v0.2.0` device dataplane transport.
+
+It replaces the `v0.1` assumption that the daemon socket surface is the only
+socket interface in the system. In `v0.2.0`, per-device dataplane sockets and
+the structured control plane are intentionally separated.
+
+## 1. Overview
+
+VirtRTLab uses two socket families in `v0.2.0`:
+
+| Interface | Path | Payload | Consumer |
+|---|---|---|---|
+| Control socket | `/run/virtrtlab/control.sock` | JSON Lines | CLI, harnesses |
+| Device data socket | `/run/virtrtlab/devices/<device>.sock` | device-specific raw dataplane | simulator process |
+
+This document covers only the device dataplane sockets.
+
+## 2. Common device dataplane rules
+
+| Property | Value |
+|---|---|
+| Path pattern | `/run/virtrtlab/devices/<device>.sock` |
+| Address family | `AF_UNIX` |
+| Socket type | `SOCK_STREAM` |
+| Framing | device-specific, no control-plane framing |
+| Direction | device-specific |
+
+The AUT never opens this socket directly.
+
+Common rules:
+
+- each device that declares a dataplane exposes exactly one dataplane socket
+- the simulator uses the dataplane socket without configuring the AUT-facing controller
+- controller configuration remains the responsibility of the AUT through normal Linux interfaces such as `termios`, sysfs, or `ioctl`
+- fault injection remains controlled through the control plane, not through the dataplane socket
+
+## 3. Per-device mapping
+
+| VirtRTLab device | Socket path |
+|---|---|
+| `uart0` | `/run/virtrtlab/devices/uart0.sock` |
+| `gpio0` | `/run/virtrtlab/devices/gpio0.sock` |
+
+There is no multiplexed global data socket in `v0.2.0`.
+
+## 4. Connection semantics
+
+| Rule | Required behavior |
+|---|---|
+| active connection count | one active simulator connection per dataplane socket |
+| second connection while occupied | rejected |
+| control separation | no control-plane request or response is carried on the dataplane socket |
+
+## 5. UART dataplane
+
+The UART dataplane socket carries a bidirectional raw byte stream.
+
+| Property | Value |
+|---|---|
+| Socket path | `/run/virtrtlab/devices/uartN.sock` |
+| Payload | raw bytes |
+| Direction | bidirectional |
+| Byte order | preserved end to end |
+| Framing | none; no line or length framing |
+
+The simulator does not configure baud rate, parity, stop bits, or other UART
+controller properties through this socket. Those properties remain under AUT
+control through `termios` on the AUT-facing TTY endpoint.
+
+## 6. GPIO dataplane
+
+The GPIO dataplane socket carries bank-state data for one GPIO device.
+
+In the base `v0.2.0` contract, one data unit is one octet representing the
+physical state of one 8-line GPIO bank.
+
+| Property | Value |
+|---|---|
+| Socket path | `/run/virtrtlab/devices/gpioN.sock` |
+| Payload width | 1 octet |
+| Line mapping | bit `L` represents physical line `L` |
+| Direction | bidirectional |
+
+GPIO bank-state rules:
+
+- bit `0` maps to line `0`
+- bit `7` maps to line `7`
+- only GPIO devices exposing exactly 8 physical lines are in scope for the
+	dataplane socket contract in `v0.2.0`
+- the octet represents the physical line state, not an AUT-specific logical view after `active_low`
+- a simulator write updates the bank-state input side presented to the driver according to the GPIO driver contract
+- a simulator read returns the current physical bank state exported by the driver dataplane side
+
+GPIO devices with a different physical line count may still be VirtRTLab
+devices, but they are outside the `v0.2.0` GPIO dataplane socket contract
+unless a later version defines a wider framing rule.
+
+The simulator does not configure direction, edge detection, bias, `active_low`,
+or line ownership through this socket. Those properties remain under AUT
+control through the normal Linux GPIO userspace interfaces.
+
+## 7. Reset and disconnect behavior
+
+| Event | Required behavior |
+|---|---|
+| simulator disconnect | daemon closes the dataplane session for that device and returns to waiting state |
+| bus or device reset invalidates the current data path | daemon closes and recreates the affected internal relay resources; the simulator connection is dropped |
+| device destroy | the data socket disappears for that device |
+
+Type-specific notes:
+
+- for UART, disconnect handling may flush stale AUT-to-simulator bytes before returning to waiting state
+- for GPIO, disconnect handling must not reconfigure the AUT-owned line parameters; only dataplane connectivity is reset
+
+## 8. Fault-model interaction
+
+The dataplane socket sees the device data after the active driver contract has
+applied the configured transport semantics for that simulator-facing direction.
+
+Rules:
+
+- persistent fault attrs are controlled through the control socket
+- one-shot fault injection is controlled through the control socket
+- the dataplane socket itself carries only device dataplane payloads
+
+## 9. Permissions
+
+| Property | Required outcome |
+|---|---|
+| owner/group | group-visible to `virtrtlab` |
+| mode | `0660` |
+| intended effect | simulator processes run without root |
+
+## 10. Rationale
+
+**Why generalize to one dataplane socket per device?**  
+It gives all simulator-facing devices a uniform integration model while keeping
+AUT configuration responsibilities on the AUT side.
+
+**Why keep controller configuration out of the dataplane?**  
+The AUT must believe it is talking to a real controller. Baud rate, parity,
+GPIO direction, edge settings, and similar controller configuration belong to
+the AUT-facing Linux interfaces, not to the simulator-facing dataplane.
+
+**Why version this document?**  
+Because `v0.2.0` turns the dataplane into a first-class per-device concept and
+extends it beyond UART.

--- a/docs/v0.2.0/socket-api-v0.2.0.md
+++ b/docs/v0.2.0/socket-api-v0.2.0.md
@@ -52,7 +52,7 @@ There is no multiplexed global data socket in `v0.2.0`.
 | Rule | Required behavior |
 |---|---|
 | active connection count | one active simulator connection per dataplane socket |
-| second connection while occupied | rejected |
+| second connection while occupied | `connect()` on the second socket MUST fail with `ECONNREFUSED`; the daemon MUST NOT accept then immediately close the second connection |
 | control separation | no control-plane request or response is carried on the dataplane socket |
 
 ## 5. UART dataplane
@@ -90,7 +90,7 @@ GPIO bank-state rules:
 - bit `0` maps to line `0`
 - bit `7` maps to line `7`
 - only GPIO devices exposing exactly 8 physical lines are in scope for the
-	dataplane socket contract in `v0.2.0`
+  dataplane socket contract in `v0.2.0`
 - the octet represents the physical line state, not an AUT-specific logical view after `active_low`
 - a simulator write updates the bank-state input side presented to the driver according to the GPIO driver contract
 - one simulator write is one atomic bank-state update request for the full octet

--- a/docs/v0.2.0/socket-api-v0.2.0.md
+++ b/docs/v0.2.0/socket-api-v0.2.0.md
@@ -23,7 +23,7 @@ This document covers only the device dataplane sockets.
 
 | Property | Value |
 |---|---|
-| Path pattern | `/run/virtrtlab/devices/<device>.sock` |
+| Path pattern | resolved dataplane path per device; default installed pattern `/run/virtrtlab/devices/<device>.sock` |
 | Address family | `AF_UNIX` |
 | Socket type | `SOCK_STREAM` |
 | Framing | device-specific, no control-plane framing |
@@ -93,6 +93,8 @@ GPIO bank-state rules:
 	dataplane socket contract in `v0.2.0`
 - the octet represents the physical line state, not an AUT-specific logical view after `active_low`
 - a simulator write updates the bank-state input side presented to the driver according to the GPIO driver contract
+- one simulator write is one atomic bank-state update request for the full octet
+- if any targeted line is currently owned by the AUT as output, the whole write is rejected with the driver-contract `state-conflict` outcome and no bit in the octet takes effect
 - a simulator read returns the current physical bank state exported by the driver dataplane side
 
 GPIO devices with a different physical line count may still be VirtRTLab
@@ -109,7 +111,7 @@ control through the normal Linux GPIO userspace interfaces.
 |---|---|
 | simulator disconnect | daemon closes the dataplane session for that device and returns to waiting state |
 | bus or device reset invalidates the current data path | daemon closes and recreates the affected internal relay resources; the simulator connection is dropped |
-| device destroy | the data socket disappears for that device |
+| device destroy | existing sessions are closed, new connections fail because the endpoint no longer exists, and the data socket path disappears for that device |
 
 Type-specific notes:
 

--- a/docs/v0.2.0/spec-v0.2.0.md
+++ b/docs/v0.2.0/spec-v0.2.0.md
@@ -1,0 +1,127 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+
+# VirtRTLab Architecture and Interface Specification (v0.2.0 Draft)
+
+This document is the source of truth for the `v0.2.0` architecture.
+
+It preserves the naming and device-model goals of VirtRTLab while changing one
+core assumption from `v0.1`: device instances are now expected to be dynamic and
+the daemon owns the canonical write-side control plane.
+
+## 1. Architectural summary
+
+VirtRTLab `v0.2.0` is built around three planes:
+
+| Plane | Surface | Role |
+|---|---|---|
+| AUT plane | `/dev/ttyVIRTLABN`, `/dev/gpiochipM`, other device nodes | the AUT talks to simulated peripherals through standard Linux interfaces |
+| Data plane | `/run/virtrtlab/devices/<device>.sock` | simulator-facing per-device dataplane |
+| Control plane | `/run/virtrtlab/control.sock` | topology, faults, stats, simulator lifecycle |
+
+Architectural boundary:
+
+- the AUT configures the simulated controller through the same Linux interfaces it would use on real hardware
+- the simulator exchanges device dataplane payloads through the per-device socket
+- the CLI and harnesses use the control plane for topology, stats, and fault injection
+
+## 2. Naming conventions
+
+| Object | Convention | Example |
+|---|---|---|
+| Device type | lowercase ASCII | `uart`, `gpio` |
+| Device instance | `<type><N>` | `uart0`, `gpio0` |
+| Control socket | fixed path | `/run/virtrtlab/control.sock` |
+| Device data socket | `/run/virtrtlab/devices/<device>.sock` | `/run/virtrtlab/devices/uart0.sock` |
+
+## 3. Device lifecycle model
+
+In `v0.2.0`, device instances are runtime objects.
+
+| Operation | Meaning |
+|---|---|
+| create | instantiate one new device without reloading the driver module |
+| destroy | remove one existing device without unloading sibling instances |
+| reset | restore one existing device to its documented reset baseline |
+
+The module-load boundary is no longer the normal configuration boundary.
+
+## 4. Control-plane model
+
+The daemon is the canonical write-side controller.
+
+Normative references:
+
+- [control-socket-v0.2.0.md](control-socket-v0.2.0.md)
+- [daemon-v0.2.0.md](daemon-v0.2.0.md)
+- [privilege-model-v0.2.0.md](privilege-model-v0.2.0.md)
+
+Read-side sysfs observability remains part of the platform contract.
+
+## 5. Driver integration model
+
+Each VirtRTLab-compatible driver must satisfy:
+
+- the dynamic device-lifecycle contract in
+  [driver-contract-v0.2.0.md](driver-contract-v0.2.0.md)
+- the control-plane capability discovery expectations
+- stable naming and resolved path reporting
+
+## 6. Simulator integration model
+
+Simulator discovery, attachment, and runtime context remain defined by:
+
+- [simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md)
+- [virtrtlabctl-v0.2.0.md](virtrtlabctl-v0.2.0.md)
+
+The key architectural rule is now:
+
+**simulators attach to dynamic VirtRTLab device instances that are created and
+managed through the daemon control plane.**
+
+## 7. Privilege model summary
+
+| Operation class | Canonical path |
+|---|---|
+| lab topology changes | control socket |
+| persistent fault configuration | control socket |
+| one-shot injection | control socket |
+| simulator lifecycle | control socket |
+| runtime diagnostics | control socket or read-side sysfs |
+
+## 8. Milestone focus
+
+The `v0.2.0` architecture now includes the following cross-cutting themes:
+
+| Theme | Meaning |
+|---|---|
+| hotpluggable device instances | no routine `insmod`/`rmmod` during test sequencing |
+| daemonized control plane | one canonical non-root control surface |
+| simulator orchestration | attachments, catalog discovery, lifecycle state |
+| driver contract | standard integration rules for future VirtRTLab-compatible drivers |
+
+## 9. Rationale
+
+**Why version the architecture doc instead of editing `spec.md`?**  
+Because `spec.md` still describes the observable world of the current
+implementation. `v0.2.0` needs a separate architectural source of truth until the
+new model is implemented.
+
+**Why treat dynamic topology as an architectural concern?**  
+Once devices are created and destroyed at runtime, topology affects privilege,
+control sequencing, simulator state, and driver design. It is no longer an
+implementation detail of module parameters.
+
+## 10. Decision
+
+`v0.2.0` keeps one shared kernel-visible VirtRTLab aggregation object for
+discovery and diagnostics.
+
+The architecture therefore standardizes two distinct layers:
+
+- one common, kernel-visible VirtRTLab aggregation point used for discovery,
+  observability, and coherent documentation
+- driver-specific internal implementation details that remain unconstrained as
+  long as the observable contract stays stable
+
+The aggregation object may continue to appear as a shared bus or equivalent
+common hierarchy anchor such as `vrtlbus0`.

--- a/docs/v0.2.0/spec-v0.2.0.md
+++ b/docs/v0.2.0/spec-v0.2.0.md
@@ -15,8 +15,8 @@ VirtRTLab `v0.2.0` is built around three planes:
 | Plane | Surface | Role |
 |---|---|---|
 | AUT plane | `/dev/ttyVIRTLABN`, `/dev/gpiochipM`, other device nodes | the AUT talks to simulated peripherals through standard Linux interfaces |
-| Data plane | `/run/virtrtlab/devices/<device>.sock` | simulator-facing per-device dataplane |
-| Control plane | `/run/virtrtlab/control.sock` | topology, faults, stats, simulator lifecycle |
+| Data plane | resolved per-device dataplane socket, default installed pattern `/run/virtrtlab/devices/<device>.sock` | simulator-facing per-device dataplane |
+| Control plane | resolved daemon control socket, default installed path `/run/virtrtlab/control.sock` | topology, faults, stats, simulator lifecycle |
 
 Architectural boundary:
 
@@ -30,8 +30,8 @@ Architectural boundary:
 |---|---|---|
 | Device type | lowercase ASCII | `uart`, `gpio` |
 | Device instance | `<type><N>` | `uart0`, `gpio0` |
-| Control socket | fixed path | `/run/virtrtlab/control.sock` |
-| Device data socket | `/run/virtrtlab/devices/<device>.sock` | `/run/virtrtlab/devices/uart0.sock` |
+| Control socket | one resolved path per daemon instance; default installed path `/run/virtrtlab/control.sock` | `/run/virtrtlab/control.sock` |
+| Device data socket | one resolved path per device; default installed pattern `/run/virtrtlab/devices/<device>.sock` | `/run/virtrtlab/devices/uart0.sock` |
 
 ## 3. Device lifecycle model
 
@@ -48,6 +48,11 @@ The module-load boundary is no longer the normal configuration boundary.
 ## 4. Control-plane model
 
 The daemon is the canonical write-side controller.
+
+Topology-oriented control requests reconcile the active lab toward the requested
+target state. In particular, `lab.up` is not limited to an `empty` starting
+state: from any stable lab state, it validates the requested target first and
+then converges device inventory and attachment definitions toward that target.
 
 Normative references:
 

--- a/docs/v0.2.0/virtrtlabctl-v0.2.0.md
+++ b/docs/v0.2.0/virtrtlabctl-v0.2.0.md
@@ -4,9 +4,26 @@
 
 This document contains **draft CLI specification** for `v0.2.0` features that are not implemented in `v0.1.x` yet.
 
-It exists to avoid mixing forward-looking interface design with the current stable CLI reference in [virtrtlabctl.md](virtrtlabctl.md).
+It exists to avoid mixing forward-looking interface design with the current stable CLI reference in [../virtrtlabctl.md](../virtrtlabctl.md).
 
-The source of truth for the simulator runtime model remains [simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md).
+In `v0.2.0`, `virtrtlabctl` is a client of the daemon control plane. The
+canonical write-side control path is the daemon control socket specified in
+[control-socket-v0.2.0.md](control-socket-v0.2.0.md).
+
+The source of truth for the simulator runtime model remains
+[simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md). The broader
+`v0.2.0` architecture is defined in [spec-v0.2.0.md](spec-v0.2.0.md).
+
+## 0. Control-plane assumptions
+
+Unless stated otherwise, every `v0.2.0` CLI command described in this document:
+
+- connects to `/run/virtrtlab/control.sock`
+- sends one structured control request to the daemon
+- renders the daemon result in human-readable or JSON CLI form
+
+The CLI is therefore not the source of truth for topology or simulator state.
+It is the stable operator-facing frontend for the daemon-owned control plane.
 
 ---
 
@@ -25,7 +42,7 @@ virtrtlabctl sim status [<device>]
 virtrtlabctl sim logs <device> [--stderr] [--tail N] [--follow]
 ```
 
-All `sim` commands accept the global `--json` flag documented in [virtrtlabctl.md](virtrtlabctl.md).
+All `sim` commands accept the global `--json` flag documented in [../virtrtlabctl.md](../virtrtlabctl.md).
 
 When `--json` is used:
 
@@ -33,6 +50,11 @@ When `--json` is used:
 - for streaming commands (`sim logs`), JSON mode is not supported: the command MUST fail fast, print the standard error envelope `{"error": "...", "code": N}` on stdout, write a brief diagnostic to stderr, and exit with a stable non-zero status code
 - failures for all commands must use the stable error envelope `{"error": "...", "code": N}`
 - human-oriented aligned text is suppressed from stdout
+
+For successful non-streaming commands, the JSON document printed by the CLI is
+exactly the daemon `result` payload from the control socket, with the transport
+envelope fields `id` and `ok` removed. The CLI must not rename fields, change
+types, or restructure the payload.
 
 Human-readable mode contract:
 
@@ -182,7 +204,7 @@ Golden-fixture expectation:
 - `sim inspect` human-readable fixtures must preserve label order and parameter row order
 - `sim inspect` JSON fixtures must preserve parameter array order as emitted by the command
 
-When multiple visible versions share the same simulator name, `sim inspect <name>` without `--version` must fail with an ambiguity error.
+When multiple visible versions share the same simulator name, `sim inspect <name>` without `--version` must fail with the daemon error `ambiguous-simulator-version`, which the CLI maps to exit code `2`.
 
 ### `sim attach`
 
@@ -202,7 +224,7 @@ Behaviour:
 - validates that the target device exists
 - validates that the simulator exists and supports the device type
 - validates every `--set key=value` assignment against the simulator parameter declarations
-- writes runtime attachment state under the VirtRTLab runtime directory
+- submits the attachment request to the daemon, which owns the runtime attachment state
 - does not start the simulator process automatically unless the command is later combined with `sim start` or a profile-driven `up`
 
 `--set` contract in `v0.2.0`:
@@ -218,8 +240,13 @@ Behaviour:
 Version-selection contract:
 
 - `--version VERSION` pins attachment selection to one explicit simulator version
-- if `--version` is omitted and multiple visible versions share the same simulator name, `sim attach` fails with an ambiguity error
+- if `--version` is omitted and multiple visible versions share the same simulator name, `sim attach` fails with the daemon error `ambiguous-simulator-version`, which the CLI maps to exit code `2`
 - direct `sim attach` defaults to `auto_start = false` unless `--auto-start` is specified explicitly
+
+Attachment replacement rules:
+
+- `sim attach` replaces an existing attachment only when the current state is `attached`, `stopped`, or `failed`
+- attempting replacement while the current attachment is `starting`, `running`, or `stopping` fails with a state conflict
 
 Validation rules:
 
@@ -244,6 +271,7 @@ JSON output example:
 {
   "device": "uart0",
   "simulator": "loopback",
+  "version": "1.0.0",
   "state": "attached",
   "auto_start": false
 }
@@ -316,6 +344,7 @@ JSON output example:
 {
   "device": "uart0",
   "simulator": "loopback",
+  "version": "1.0.0",
   "state": "running",
   "pid": 14523
 }
@@ -406,12 +435,17 @@ Detailed-field contract:
 - when present for failure cases, `last error`, `last exit code`, and `stopped at` are appended after `log dir` in that order
 - labels are lowercase and space-separated exactly as shown
 
-Runtime state is stored under `/run/virtrtlab/simulators/`; see [simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md) for the exact layout.
+The daemon control plane is the source of truth for simulator lifecycle state.
+The runtime files under `/run/virtrtlab/simulators/` are daemon-owned runtime
+artifacts used to persist attachment state and logs; see
+[simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md) for the exact
+layout.
 
-The per-device state file is `/run/virtrtlab/simulators/<device>/state.json` and is the source of truth for lifecycle state, timestamps, PID, and the last observed failure.
-
-If `/run/virtrtlab/simulators/` does not exist, `sim status` without a device argument returns an empty set.
-If `/run/virtrtlab/simulators/<device>/state.json` does not exist, `sim status <device>` returns a not-found error.
+If the daemon is unavailable, `sim status` fails with a normal daemon-unavailable
+error. If the daemon is available but no attachments exist, `sim status` without
+a device argument returns an empty set. If the target device exists but has no
+attachment, `sim status <device>` returns the daemon error `not-attached`, which
+the CLI maps to exit code `4`.
 
 When the attachment is in `failed`, the detailed human-readable output must also include `last error`, `last exit code`, and `stopped at`.
 
@@ -541,7 +575,7 @@ description = "Delay before echoing received bytes back to the AUT"
 |---|---|
 | 0 | Success |
 | 1 | Operational error (spawn failure, stop timeout, filesystem error) |
-| 2 | Invalid arguments or invalid `--set key=value` syntax |
+| 2 | Invalid arguments, ambiguous simulator version selection, or invalid `--set key=value` syntax |
 | 3 | State conflict (already running, already attached, already starting) |
 | 4 | Not found or incompatible target (unknown simulator, unknown device, unsupported device type, no attachment) |
 
@@ -556,13 +590,18 @@ Recommended error mapping:
 | malformed `--set key=value` | 2 |
 | invalid value type for declared parameter | 2 |
 | missing required positional argument | 2 |
+| ambiguous simulator version selection | 2 |
 | `sim start` while already `running` | 3 |
 | `sim start` while already `starting` | 3 |
+| `sim attach` while an attachment is `running`, `starting`, or `stopping` | 3 |
+| `sim stop` on an `attached` or `failed` attachment | 3 |
 | lifecycle lock acquisition timeout | 1 |
 | unknown device | 4 |
 | unknown simulator | 4 |
 | unsupported device type for selected simulator | 4 |
 | `sim start` on detached device | 4 |
+| `sim detach` on detached device | 4 |
+| `sim status <device>` on unattached device | 4 |
 
 JSON failure examples:
 
@@ -616,7 +655,8 @@ auto_start = true
 delay_ms = 0
 ```
 
-`virtrtlabctl up --config ...` will validate `[[attachments]]` before partial startup.
+`virtrtlabctl up --config ...` sends the resolved profile to the daemon, which
+validates `[[attachments]]` before partial startup.
 If `auto_start` is omitted, the effective default comes from the simulator catalog `default_auto_start`; otherwise it falls back to `false`.
 Only attachments whose effective auto-start value is `true` are started automatically.
 

--- a/docs/v0.2.0/virtrtlabctl-v0.2.0.md
+++ b/docs/v0.2.0/virtrtlabctl-v0.2.0.md
@@ -18,7 +18,7 @@ The source of truth for the simulator runtime model remains
 
 Unless stated otherwise, every `v0.2.0` CLI command described in this document:
 
-- connects to `/run/virtrtlab/control.sock`
+- connects to the resolved daemon control socket, whose default installed path is `/run/virtrtlab/control.sock`
 - sends one structured control request to the daemon
 - renders the daemon result in human-readable or JSON CLI form
 
@@ -439,7 +439,8 @@ The daemon control plane is the source of truth for simulator lifecycle state.
 The runtime files under `/run/virtrtlab/simulators/` are daemon-owned runtime
 artifacts used to persist attachment state and logs; see
 [simulator-contract-v0.2.0.md](simulator-contract-v0.2.0.md) for the exact
-layout.
+layout. These runtime files are an observability surface for simulator
+lifecycle only; they are not a second control-plane authority.
 
 If the daemon is unavailable, `sim status` fails with a normal daemon-unavailable
 error. If the daemon is available but no attachments exist, `sim status` without
@@ -598,7 +599,7 @@ Recommended error mapping:
 | lifecycle lock acquisition timeout | 1 |
 | unknown device | 4 |
 | unknown simulator | 4 |
-| unsupported device type for selected simulator | 4 |
+| incompatible target for selected simulator | 4 |
 | `sim start` on detached device | 4 |
 | `sim detach` on detached device | 4 |
 | `sim status <device>` on unattached device | 4 |

--- a/docs/v0.2.0/virtrtlabctl-v0.2.0.md
+++ b/docs/v0.2.0/virtrtlabctl-v0.2.0.md
@@ -448,6 +448,11 @@ a device argument returns an empty set. If the target device exists but has no
 attachment, `sim status <device>` returns the daemon error `not-attached`, which
 the CLI maps to exit code `4`.
 
+Reconnect note:
+
+- after a bus or device reset, `sim status <device>` may continue to report `running` while the simulator is still retrying connection to the dataplane socket
+- when reconnect timing matters, operators and CI should combine `sim status` with a device-level dataplane probe or higher-level smoke check instead of treating `running` as a reconnect guarantee
+
 When the attachment is in `failed`, the detailed human-readable output must also include `last error`, `last exit code`, and `stopped at`.
 
 JSON output example for `sim status uart0`:
@@ -578,7 +583,7 @@ description = "Delay before echoing received bytes back to the AUT"
 | 1 | Operational error (spawn failure, stop timeout, filesystem error) |
 | 2 | Invalid arguments, ambiguous simulator version selection, or invalid `--set key=value` syntax |
 | 3 | State conflict (already running, already attached, already starting) |
-| 4 | Not found or incompatible target (unknown simulator, unknown device, unsupported device type, no attachment) |
+| 4 | Not found or incompatible target (unknown simulator, unknown device, incompatible target, no attachment) |
 
 Recommended error mapping:
 
@@ -611,7 +616,17 @@ JSON failure examples:
 ```
 
 ```json
+{"error": "incompatible target: loopback does not support gpio0", "code": 4}
+```
+
+```json
 {"error": "state conflict: uart0 is already running", "code": 3}
+```
+
+Human-readable incompatible-target example:
+
+```text
+[error] incompatible target: loopback does not support gpio0
 ```
 
 ### State transitions


### PR DESCRIPTION
## Contexte
Cette PR clôt la passe de revue exhaustive de la spécification v0.2.0 et intègre les décisions normatives retenues pour supprimer les ambiguïtés inter-docs.

## Changements
- harmonise les chemins runtime comme chemins résolus avec chemins installés par défaut, au lieu de chemins figés
- formalise `lab.up` comme opération de réconciliation avec phases et garanties d’atomicité explicites
- aligne les contrats de destruction, d’état de device, de `stats/reset` et des erreurs `incompatible-target`
- borne les attributs persistants communs avec maxima découvrables via capabilities
- clarifie les règles GPIO sur conflit de possession AUT et la reconnexion simulateur après reset
- confirme que les fichiers runtime sous `/run` restent une surface d’observabilité simulateur et non une seconde API de topologie
- ajoute des exemples JSON/humains complémentaires dans le draft CLI et le contrôle socket

## Tests effectués
- [x] `make check` passe sans erreur
- [ ] `make qa` passe si le CLI ou le daemon sont touchés
- [ ] `make qa-kernel-lint` passe si `kernel/**` est touché
- [x] `python3 -m pytest -c pytest.ini tests/cli` passe (`84 passed, 15 skipped`)
- [x] `python3 -m pytest -c pytest.ini tests/daemon` passe (`14 skipped`, sudo non disponible)
- [x] `python3 -m pytest -c pytest.ini tests/kernel` passe (`279 skipped`, sudo non disponible)
- [x] `python3 -m pytest -c pytest.ini tests/install` passe (`14 passed`)
- [ ] Module charge/décharge sans oops (`dmesg` propre)
- [ ] `checkpatch.pl --strict` sans erreur

## Notes pour le reviewer
- Cette branche contient deux commits docs ciblés: le premier resserre les contrats v0.2.0, le second termine les follow-ups de review avec les exemples et précisions restantes.
- Les suites `daemon` et `kernel` sont entièrement skippées dans cet environnement faute de sudo sans mot de passe ; aucun fichier de code n’a été modifié dans cette PR.